### PR TITLE
fix: promise.withResolvers polyfill added to createCallable

### DIFF
--- a/lib/createCallable/index.tsx
+++ b/lib/createCallable/index.tsx
@@ -6,6 +6,20 @@ import type {
   Callable,
 } from './types'
 
+const PromiseWithResolvers = <Response,>() => {
+  let resolve: (value: Response | PromiseLike<Response>) => void
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  let reject: (reason?: any) => void
+
+  const promise = new Promise<Response>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  // @ts-ignore
+  return { promise, resolve, reject }
+}
+
 export function createCallable<Props = void, Response = void, RootProps = {}>(
   UserComponent: UserComponentType<Props, Response, RootProps>,
 ): Callable<Props, Response, RootProps> {
@@ -17,7 +31,7 @@ export function createCallable<Props = void, Response = void, RootProps = {}>(
       if ($setStack === null) throw new Error('No <Root> found!')
 
       const key = String($nextKey++)
-      const promise = Promise.withResolvers<Response>()
+      const promise = PromiseWithResolvers<Response>()
 
       const end = (response: Response) => {
         if ($setStack === null) return


### PR DESCRIPTION
Fixes: #11 

### What does this PR do?

- Adds a polyfill for the Promise.withResolvers method to prevent access to a non-existent property.

Reference: [MDN Web Docs - Promise.withResolvers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers#description)