### PR TITLE
Add upsert implementation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,41 @@ Alert.update({ message: 'Completed!' })
 
 This may also be cleaner for you if you're sure that only one call is run at once in your code.
 
+When you need to ensure only one instance of a component is active at a time, use `upsert()` instead of `call()`. This is particularly useful for notifications, loading states, or any singleton-like UI:
+
+```tsx
+// First call creates a new instance
+const promise1 = Toast.upsert({ message: 'Loading...' })
+
+// Second call updates the existing instance instead of creating a new one
+const promise2 = Toast.upsert({ message: 'Almost done...' })
+
+// promise1 === promise2 (same instance)
+console.log(promise1 === promise2) // true
+```
+
+The `upsert()` method behaves as follows:
+
+- **Creates** a new instance if no upsert instance is currently active
+- **Updates** the existing upsert instance if one is already active  
+- **Does not affect** normal `call()` instances
+- **Creates** a new instance if the previous upsert instance was ended
+
+```tsx
+// Example: Progress notification that updates itself
+const showProgress = async () => {
+  Toast.upsert({ message: 'Starting download...' })
+  
+  for (let i = 0; i <= 100; i += 10) {
+    await new Promise(resolve => setTimeout(resolve, 100))
+    Toast.upsert({ message: `Progress: ${i}%` })
+  }
+  
+  // End the notification
+  Toast.end(true)
+}
+```
+
 # Exit animations
 
 To animate the exit of your component when `call.end()` is run, just pass the duration of your animation in milliseconds to createCallable as a second argument:
@@ -204,6 +239,7 @@ import type { ReactCall } from 'react-call'
 Type | Description
 --- | ---
 ReactCall.Function<Props?, Response?> | The call() method
+ReactCall.UpsertFunction<Props?, Response?> | The upsert() method
 ReactCall.Context<Props?, Response?, RootProps?> | The call prop in UserComponent
 ReactCall.Props<Props?, Response?, RootProps?> | Your props + the call prop
 ReactCall.UserComponent<Props?, Response?, RootProps?> | What is passed to createCallable

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Check out [the demo site](https://react-call.desko.dev/) to see some live exampl
 
 # Advanced usage
 
-The returned promise can also be used to end the call from the caller scope:
+## End from caller
+
+The returned promise can be used to end the call from the caller scope:
 
 ```tsx
 const promise = Confirm.call({ message: 'Continue?' })
@@ -112,7 +114,16 @@ onImportantEvent(() => {
 const accepted = await promise
 ```
 
-Or even update the call props on the fly:
+While the promise argument is used to target that specific call, all ongoing calls can be affected by omitting it:
+
+```tsx
+// All confirm calls are ended with `false`
+Confirm.end(false)
+```
+
+## Update
+
+The returned promise can also be used to update the call props on the fly:
 
 ```tsx
 const promise = Alert.call({ message: 'Starting operation...' })
@@ -123,16 +134,13 @@ Alert.update(promise, { message: 'Completed!' })
 While the promise argument is used to target that specific call, all ongoing calls can be affected by omitting it:
 
 ```tsx
-// All confirm calls are ended with `false`
-Confirm.end(false)
-
 // All alert calls are updated with the new message prop
 Alert.update({ message: 'Completed!' })
 ```
 
-This may also be cleaner for you if you're sure that only one call is run at once in your code.
+## Upsert
 
-When you need to ensure only one instance of a component is active at a time, use `upsert()` instead of `call()`. This is particularly useful for notifications, loading states, or any singleton-like UI:
+If you need to ensure only one instance of a component is active at a time, use `upsert()` instead of `call()`. This is particularly useful for notifications, loading states, or any singleton-like UI:
 
 ```tsx
 // First call creates a new instance
@@ -148,7 +156,7 @@ console.log(promise1 === promise2) // true
 The `upsert()` method behaves as follows:
 
 - **Creates** a new instance if no upsert instance is currently active
-- **Updates** the existing upsert instance if one is already active  
+- **Updates** the existing upsert instance if one is already active
 - **Does not affect** normal `call()` instances
 - **Creates** a new instance if the previous upsert instance was ended
 
@@ -156,12 +164,12 @@ The `upsert()` method behaves as follows:
 // Example: Progress notification that updates itself
 const showProgress = async () => {
   Toast.upsert({ message: 'Starting download...' })
-  
+
   for (let i = 0; i <= 100; i += 10) {
     await new Promise(resolve => setTimeout(resolve, 100))
     Toast.upsert({ message: `Progress: ${i}%` })
   }
-  
+
   // End the notification
   Toast.end(true)
 }

--- a/react-call/bundlesize.config.json
+++ b/react-call/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./dist/*.js",
-      "maxSize": "750 B"
+      "maxSize": "850 B"
     }
   ]
 }

--- a/react-call/src/createCallable/index.tsx
+++ b/react-call/src/createCallable/index.tsx
@@ -78,11 +78,6 @@ export function createCallable<Props = void, Response = void, RootProps = {}>(
       })
       $upsertPromise = promise
 
-      const createUpsertEnd = (response: Response) => {
-        $upsertPromise = null
-        createEnd(promise)(response)
-      }
-
       $setStack((prev) => [
         ...prev,
         {
@@ -90,7 +85,10 @@ export function createCallable<Props = void, Response = void, RootProps = {}>(
           props,
           promise,
           resolve,
-          end: createUpsertEnd,
+          end: (response: Response) => {
+            $upsertPromise = null
+            createEnd(promise)(response)
+          },
           ended: false,
           isUpsert: true,
         },

--- a/react-call/src/createCallable/index.tsx
+++ b/react-call/src/createCallable/index.tsx
@@ -13,6 +13,7 @@ export function createCallable<Props = void, Response = void, RootProps = {}>(
 ): Callable<Props, Response, RootProps> {
   let $setStack: PrivateStackStateSetter<Props, Response> | null = null
   let $nextKey = 0
+  let $upsertPromise: Promise<Response> | null = null
 
   const createEnd =
     (promise: Promise<Response> | null) => (response: Response) => {
@@ -52,6 +53,50 @@ export function createCallable<Props = void, Response = void, RootProps = {}>(
       ])
       return promise
     },
+    upsert: (props) => {
+      if (!$setStack) throw new Error('No <Root> found!')
+
+      if ($upsertPromise) {
+        $setStack((prev) => {
+          const existingCall = prev.find(
+            (call) => call.promise === $upsertPromise && !call.ended,
+          )
+          if (existingCall) {
+            return prev.map((call) =>
+              call === existingCall ? { ...call, props } : call,
+            )
+          }
+          return prev
+        })
+        return $upsertPromise
+      }
+
+      const key = String($nextKey++)
+      let resolve: PrivateResolve<Response>
+      const promise = new Promise<Response>((res) => {
+        resolve = res
+      })
+      $upsertPromise = promise
+
+      const createUpsertEnd = (response: Response) => {
+        $upsertPromise = null
+        createEnd(promise)(response)
+      }
+
+      $setStack((prev) => [
+        ...prev,
+        {
+          key,
+          props,
+          promise,
+          resolve,
+          end: createUpsertEnd,
+          ended: false,
+          isUpsert: true,
+        },
+      ])
+      return promise
+    },
     end: (...args: [Promise<Response>, Response] | [Response]) => {
       const targeted = args.length === 2
       return createEnd(targeted ? args[0] : null)(targeted ? args[1] : args[0])
@@ -82,6 +127,7 @@ export function createCallable<Props = void, Response = void, RootProps = {}>(
         $setStack = setStack
         return () => {
           $setStack = null
+          $upsertPromise = null
           $nextKey = 0
         }
       }, [])

--- a/react-call/src/createCallable/types.ts
+++ b/react-call/src/createCallable/types.ts
@@ -9,6 +9,7 @@ export interface PrivateCallContext<Props, Response> {
   resolve: PrivateResolve<Response>
   end: (response: Response) => void
   ended: boolean
+  isUpsert?: boolean
 }
 export type PrivateStackState<Props, Response> = PrivateCallContext<
   Props,
@@ -22,6 +23,13 @@ export type PrivateStackStateSetter<Props, Response> = React.Dispatch<
  * The call() method
  */
 export type CallFunction<Props, Response> = (props: Props) => Promise<Response>
+
+/**
+ * The upsert() method
+ */
+export type UpsertFunction<Props, Response> = (
+  props: Props,
+) => Promise<Response>
 
 /**
  * The special call prop in UserComponent
@@ -51,6 +59,7 @@ export type UserComponent<Props, Response, RootProps> = React.FunctionComponent<
 export type Callable<Props, Response, RootProps> = {
   Root: React.FunctionComponent<RootProps>
   call: CallFunction<Props, Response>
+  upsert: UpsertFunction<Props, Response>
   end: ((promise: Promise<Response>, response: Response) => void) &
     ((response: Response) => void)
   update: ((promise: Promise<Response>, props: Partial<Props>) => void) &

--- a/react-call/src/types.public.ts
+++ b/react-call/src/types.public.ts
@@ -1,5 +1,6 @@
 export type {
   CallFunction as Function,
+  UpsertFunction,
   CallContext as Context,
   PropsWithCall as Props,
   UserComponent,

--- a/tests/src/upsert.test.tsx
+++ b/tests/src/upsert.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { Confirm } from './shared/Confirm'
+
+describe('upsert()', () => {
+  test('creates new instance when called without existing instance', async () => {
+    const screen = render(<Confirm.Root />)
+    Confirm.upsert({ message: 'Hello' })
+
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Hello' }))
+      .toBeInTheDocument()
+  })
+
+  test('updates existing instance when called with existing instance', async () => {
+    const screen = render(<Confirm.Root />)
+
+    const promise1 = Confirm.upsert({ message: 'First' })
+
+    await expect
+      .element(screen.getByRole('dialog', { name: 'First' }))
+      .toBeInTheDocument()
+
+    const promise2 = Confirm.upsert({ message: 'Updated' })
+
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Updated' }))
+      .toBeInTheDocument()
+
+    const dialogs = screen.container.querySelectorAll('[role="dialog"]')
+    expect(dialogs.length).toBe(1)
+
+    expect(promise1).toBe(promise2)
+  })
+
+  test('does not affect normal calls', async () => {
+    const screen = render(<Confirm.Root />)
+
+    Confirm.call({ message: 'Normal 1' })
+
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Normal 1' }))
+      .toBeInTheDocument()
+
+    Confirm.upsert({ message: 'Upsert 1' })
+
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Upsert 1' }))
+      .toBeInTheDocument()
+
+    Confirm.call({ message: 'Normal 2' })
+
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Normal 2' }))
+      .toBeInTheDocument()
+
+    const dialogsBefore = screen.container.querySelectorAll('[role="dialog"]')
+    expect(dialogsBefore.length).toBe(3)
+
+    Confirm.upsert({ message: 'Upsert Updated' })
+
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Upsert Updated' }))
+      .toBeInTheDocument()
+
+    const dialogsAfter = screen.container.querySelectorAll('[role="dialog"]')
+    expect(dialogsAfter.length).toBe(3)
+  })
+
+  test('creates new instance after previous one is ended', async () => {
+    const screen = render(<Confirm.Root />)
+
+    Confirm.upsert({ message: 'First' })
+
+    await expect
+      .element(screen.getByRole('dialog', { name: 'First' }))
+      .toBeInTheDocument()
+
+    await screen.getByRole('button', { name: /yes/i }).click()
+
+    await expect
+      .element(screen.container.querySelector('[role="dialog"]'))
+      .not.toBeInTheDocument()
+
+    Confirm.upsert({ message: 'Second' })
+
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Second' }))
+      .toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### 🚀 Feature: Add upsert method for singleton-like component instances

#### Description

This pull request introduces a new feature: **`upsert()` method**.
It allows creating or updating a single active instance of a callable component, ensuring only one instance exists at a time. This is particularly useful for notifications, toasts, loading states, or any UI element that should be displayed as a singleton.

#### Motivation

- Many UI patterns require showing only one instance of a component at a time (e.g., a loading indicator that updates its progress, or a notification that changes its message)
- This feature provides a clean, declarative API for "create if not exists, update if exists" behavior

#### Changes

- **Added**: `upsert()` method to the callable API that creates or updates a single active instance
- **Added**: Internal tracking of upsert promises via `$upsertPromise` variable
- **Added**: `isUpsert` flag to distinguish upsert instances from regular calls
- **Added**: Comprehensive test suite for upsert functionality
- **Updated**: README with detailed documentation and usage examples
- **Updated**: TypeScript types to include `ReactCall.UpsertFunction<Props?, Response?>`

#### Usage Example

```tsx
// Progress notification that updates itself
const showProgress = async () => {
  Toast.upsert({ message: 'Starting download...' })

  await new Promise(resolve => setTimeout(resolve, 1000))

  for (let i = 0; i <= 100; i += 1) {
    await new Promise(resolve => setTimeout(resolve, 100))
    Toast.upsert({ message: `Progress: ${i}%` })
  }

  Toast.end(true)
}

// Returns the same promise when updating
const promise1 = Toast.upsert({ message: 'Loading...' })
const promise2 = Toast.upsert({ message: 'Almost done...' })
console.log(promise1 === promise2) // true
```

#### Screenshots / Demos

https://github.com/user-attachments/assets/43be6540-6d57-4364-8d71-903100bc564d

#### Related Issues

Closes #52 
Refs #21 

#### Checklist

- [x] I've added tests that prove my fix is effective or that my feature works
- [x] I've added necessary documentation (README, inline comments, examples)
- [x] I've run all tests and they pass
- [x]  I've checked for breaking changes and documented them if any

#### Notes for Reviewers

- The implementation ensures that upsert instances don't interfere with regular call() instances
- When an upsert instance is ended, the next upsert will create a new instance (not update the ended one)
- The feature is fully backward compatible - existing code using call() will continue to work unchanged
