### PR TITLE
Clear upsert promise when ending externally (#71)

### DIFF
--- a/react-call/src/createCallable/index.tsx
+++ b/react-call/src/createCallable/index.tsx
@@ -97,7 +97,12 @@ export function createCallable<Props = void, Response = void, RootProps = {}>(
     },
     end: (...args: [Promise<Response>, Response] | [Response]) => {
       const targeted = args.length === 2
-      return createEnd(targeted ? args[0] : null)(targeted ? args[1] : args[0])
+      const promise = targeted ? args[0] : null
+      const response = targeted ? args[1] : args[0]
+
+      if (!targeted || promise === $upsertPromise) $upsertPromise = null
+
+      return createEnd(promise)(response)
     },
     update: (
       ...args: [Promise<Response>, Partial<Props>] | [Partial<Props>]

--- a/tests/src/upsert.test.tsx
+++ b/tests/src/upsert.test.tsx
@@ -88,4 +88,26 @@ describe('upsert()', () => {
       .element(screen.getByRole('dialog', { name: 'Second' }))
       .toBeInTheDocument()
   })
+
+  test('creates new instance after previous one is ended externally', async () => {
+    const screen = render(<Confirm.Root />)
+
+    Confirm.upsert({ message: 'First' })
+
+    await expect
+      .element(screen.getByRole('dialog', { name: 'First' }))
+      .toBeInTheDocument()
+
+    Confirm.end(false)
+
+    await expect
+      .element(screen.container.querySelector('[role="dialog"]'))
+      .not.toBeInTheDocument()
+
+    Confirm.upsert({ message: 'Second' })
+
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Second' }))
+      .toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
### 🐛 Bug Fix: Fix upsert not working after external end() call

#### Description

This pull request fixes a bug where calling `upsert()` after ending the previous upsert instance externally via `MyCallable.end()` fails to create a new instance.

The issue occurred because the internal `$upsertPromise` variable was not being cleared when `end()` was called externally, causing subsequent `upsert()` calls to attempt updating a non-existent instance instead of creating a new one.

#### Root Cause

When an upsert instance is created, it stores the promise in `$upsertPromise`. This variable is used to determine whether to create a new instance or update an existing one.

**The problem:**
- When ending via the component's internal `call.end()` → `$upsertPromise` is cleared ✅
- When ending via external `MyCallable.end()` → `$upsertPromise` was **not** cleared ❌

This caused the next `upsert()` call to:
1. Find `$upsertPromise` still exists
2. Try to update the existing instance
3. Fail to find it in the stack (because it was already removed)
4. Return the old promise without creating a new instance

#### Solution

Modified the `end()` method to clear `$upsertPromise` when:
- Ending all calls (no specific promise target), OR
- Ending a specific promise that matches `$upsertPromise`

#### Changes

- **Fixed**: `react-call/src/createCallable/index.tsx` - Clear `$upsertPromise` in `end()` method
- **Added**: `tests/src/upsert.test.tsx` - Test case to reproduce and verify the fix

All tests now pass: ✅ 5 passed (including the new test case)

#### Related Issues

Fixes #71

#### Checklist

- [x] Bug fix implemented
- [x] Test case added to prevent regression
- [x] All existing tests still pass
- [x] No breaking changes

#### Notes for Reviewers

- The fix is minimal and focused on the root cause
- Fully backward compatible - no API changes
- All 5 upsert tests pass, including the new regression test
