### PR TITLE
refactor(react-call)!: flat type exports, remove ReactCall namespace

### DIFF
--- a/.changeset/breaking-flat-type-exports.md
+++ b/.changeset/breaking-flat-type-exports.md
@@ -1,0 +1,28 @@
+---
+"react-call": major
+---
+
+**Public types are exported as flat named exports instead of under the `ReactCall` namespace** (ADR-0015). The `ReactCall` namespace is removed in 2.0 with no deprecated alias — migration is a mechanical find-and-replace:
+
+```ts
+// Before
+import { createCallable, type ReactCall } from 'react-call'
+type MyProps = ReactCall.Props<MyInput, MyResponse>
+
+// After
+import { createCallable, type PropsWithCall } from 'react-call'
+type MyProps = PropsWithCall<MyInput, MyResponse>
+```
+
+Mapping:
+
+| Before | After |
+| --- | --- |
+| `ReactCall.Function` | `CallFunction` |
+| `ReactCall.UpsertFunction` | `UpsertFunction` |
+| `ReactCall.Context` | `CallContext` |
+| `ReactCall.Props` | `PropsWithCall` |
+| `ReactCall.UserComponent` | `UserComponent` |
+| `ReactCall.Callable` | `Callable` |
+
+This aligns the main entry with the `react-call/mutation-flow` subpath (which already exports flat names like `MutationCall`, `MutationFn`, `Trigger`) and with the convention of the broader React/TS ecosystem (React Query, React Router, TanStack Table). No runtime change — types are erased at compile time; the JS bundle is unaffected.

--- a/README.md
+++ b/README.md
@@ -375,20 +375,20 @@ No. There can only be one `<Root>` mounted per createCallable(). Avoid placing i
 
 # TypeScript types
 
-You won't need them most likely, but if you want to split the component declaration and such, you may use the types under the `ReactCall` namespace:
+You won't need them most likely, but if you want to split the component declaration and such, the public types are available as named exports:
 
 ```tsx
-import type { ReactCall } from 'react-call'
+import type { UserComponent, CallContext } from 'react-call'
 ```
 
 Type | Description
 --- | ---
-ReactCall.Function<Props?, Response?> | The call() method
-ReactCall.UpsertFunction<Props?, Response?> | The upsert() method
-ReactCall.Context<Props?, Response?, RootProps?> | The call prop in UserComponent
-ReactCall.Props<Props?, Response?, RootProps?> | Your props + the call prop
-ReactCall.UserComponent<Props?, Response?, RootProps?> | What is passed to createCallable
-ReactCall.Callable<Props?, Response?, RootProps?> | What createCallable returns
+CallFunction<Props?, Response?> | The call() method
+UpsertFunction<Props?, Response?> | The upsert() method
+CallContext<Props?, Response?, RootProps?> | The call prop in UserComponent
+PropsWithCall<Props?, Response?, RootProps?> | Your props + the call prop
+UserComponent<Props?, Response?, RootProps?> | What is passed to createCallable
+Callable<Props?, Response?, RootProps?> | What createCallable returns
 
 # Errors
 

--- a/docs/adr/0015-flat-type-exports-over-namespace.md
+++ b/docs/adr/0015-flat-type-exports-over-namespace.md
@@ -1,0 +1,45 @@
+# Public types are flat named exports, not a `ReactCall` namespace
+
+Starting with 2.0, the public TypeScript types of the main entry are exported as flat named exports (`CallFunction`, `UpsertFunction`, `CallContext`, `PropsWithCall`, `UserComponent`, `Callable`) rather than aggregated under a `ReactCall` namespace via `export type * as ReactCall`. The change is a hard break under the ADR-0003 umbrella — no deprecated alias is kept, the namespace stops being exported in 2.0.
+
+We chose this for three reasons. First, flat named exports are what the rest of the React/TS ecosystem ships (React Query, React Router, TanStack Table, Zustand) — the namespace pattern is more idiomatic in libraries where the namespace doubles as a runtime object (Zod's `z`, the `React` namespace), and ours doesn't. Second, the same package is already internally inconsistent: the `react-call/mutation-flow` subpath exports `MutationCall`, `MutationFn`, `Trigger`, `ChainTrigger` as flat names, so the namespace on the main entry was the outlier, not the convention. Third, the internal names defined in `createCallable/types.public.ts` (`CallFunction`, `CallContext`, `PropsWithCall`, etc.) already align with the canonical glossary in `CONTEXT.md` (`Callable`, `Call`, `CallContext`, `Upsert`); the namespace existed only to *rename* those internal names down to short forms like `Function`, `Context`, `Props` that would otherwise collide with built-in TypeScript types. Removing the namespace lets `internal === external`, eliminating one renaming layer (`src/types.public.ts`) entirely.
+
+The migration is purely mechanical for consumers:
+
+| Before (namespace) | After (flat) |
+|---|---|
+| `ReactCall.Function` | `CallFunction` |
+| `ReactCall.UpsertFunction` | `UpsertFunction` |
+| `ReactCall.Context` | `CallContext` |
+| `ReactCall.Props` | `PropsWithCall` |
+| `ReactCall.UserComponent` | `UserComponent` |
+| `ReactCall.Callable` | `Callable` |
+
+```ts
+// Before
+import { createCallable, type ReactCall } from 'react-call'
+type Props = ReactCall.Props<MyProps, MyResponse>
+
+// After
+import { createCallable, type PropsWithCall } from 'react-call'
+type Props = PropsWithCall<MyProps, MyResponse>
+```
+
+## Considered options
+
+- **Keep the namespace (status quo).** Permits very short names (`Function`, `Context`, `Props`) without colliding with TS builtins, and offers a single-symbol import with autocompletion under `ReactCall.`. Rejected: modern editors auto-import flat names just as smoothly, the short-name argument is weak once internal names already exist with sensible prefixes, and staying with the namespace perpetuates the internal inconsistency with the `mutation-flow` subpath.
+- **Keep `ReactCall` as a `@deprecated` alias during 2.x, remove in 3.0.** Smoother migration path. Rejected because (a) the migration is a trivial find-and-replace, (b) keeping the alias forces us to maintain the renaming layer (`Function`, `Context`, `Props` → internal names) for a whole major just for the deprecation path, and (c) ADR-0003 already establishes 2.0 as the umbrella for breaking API cleanups, so a soft path here would be inconsistent with the rest of the 2.0 changes.
+- **Adopt a `Callable*` prefix systematically (`CallableFn`, `CallableContext`, `CallableProps`, `CallableComponent`).** Maximum branding consistency. Rejected on two grounds: `CallableFunction` is already defined in TypeScript's `lib.es5.d.ts`, so the prefix can't even be applied uniformly without abbreviating to `Fn`; and renaming `CallContext` to `CallableContext` would break alignment with the canonical glossary term in `CONTEXT.md`, which exists specifically to disambiguate from React's `Context`.
+- **Hybrid (flat names but rename `PropsWithCall` → `CallableProps` and `UserComponent` → `CallableComponent`).** Slightly more consumer-friendly on the two weakest names. Rejected as bikeshedding: `CallableProps` is ambiguous (root props vs user props), and `UserComponent` is more precise than `CallableComponent` (which would read as "the component returned by createCallable" — i.e., the Root). Internal names are the right names.
+- **Publish a codemod alongside the hard break.** Premium migration UX. Rejected as overkill for six types whose migration is a find-and-replace at every callsite. The codemod would be more code to maintain than the migration it automates.
+
+## Consequences
+
+- **`src/main.ts` re-exports the types flat**, directly from `./createCallable/types.public`. The `export type * as ReactCall from './types.public'` line is removed.
+- **`src/types.public.ts` is deleted entirely.** It existed only as the renaming layer between the internal names and the namespace's short names. With internal === external, it has no purpose. Removing one file simplifies the public-surface map.
+- **The `ReactCall` symbol disappears from the package's `.d.ts` output.** This is the only consumer-visible break; the runtime bundle is unaffected (types are erased). `attw` and `publint` are unaffected — both forms (`export type * as X` and flat `export type { ... }`) are equally valid.
+- **Migration guidance ships in the 2.0 release notes and the README**: the mapping table from this ADR is reproduced in the README's "Upgrade from 1.x" section, and the changeset entry for this change links here. Consumers migrating from 1.x do one find-and-replace per type — no API semantics change.
+- **`CONTEXT.md` is not modified by this ADR.** The glossary covers domain terms (`Callable`, `Call`, `CallContext`, `Upsert`, …), and the new flat type names already align with those terms. The decision about *how* those terms are exported as TS types is implementation detail and belongs in this ADR, not the glossary.
+- **Internal test fixtures and the `<Confirm />` example components in `__tests__/shared/` migrate to flat imports.** Mechanical substitution following the table above; the lib eats its own dog food. Same precedent as ADR-0013, which migrated demos and tests after the public-surface decision landed.
+- **The README's "Types" section table is rewritten** to list flat type names directly. The previous rendering as `ReactCall.X` rows is replaced with bare type names, and the "Upgrade from 1.x" section gains the mapping table.
+- **Future public types added to the main entry follow this pattern** — flat named exports defined in `createCallable/` (or sibling module folders) and re-exported from `src/main.ts`. The convention now matches `react-call/mutation-flow`.

--- a/packages/react-call/src/__tests__/call-context.test.tsx
+++ b/packages/react-call/src/__tests__/call-context.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 import { createCallable } from '../createCallable'
-import type * as ReactCall from '../types.public'
+import type { UserComponent } from '../createCallable/types.public'
 import { withAct } from './shared/act'
 
 // Fixture that exposes the three call-context invariants we want to pin
@@ -10,10 +10,7 @@ import { withAct } from './shared/act'
 
 type Props = { id: string }
 
-const ProbeComponent: ReactCall.UserComponent<Props, void, {}> = ({
-  call,
-  id,
-}) => (
+const ProbeComponent: UserComponent<Props, void, {}> = ({ call, id }) => (
   <div
     data-testid={`probe-${id}`}
     data-key={call.key}

--- a/packages/react-call/src/__tests__/callable-types.test.ts
+++ b/packages/react-call/src/__tests__/callable-types.test.ts
@@ -1,7 +1,7 @@
 import type { FunctionComponent } from 'react'
 import { describe, expectTypeOf, test } from 'vitest'
 import { createCallable } from '../createCallable'
-import type { Callable as CallableType } from '../createCallable/types.public'
+import type { Callable } from '../createCallable/types.public'
 
 // Type-level pins for the shape of what `createCallable()` returns
 // (`Callable<>`) and for the generic-default behaviour of `createCallable`
@@ -13,31 +13,31 @@ import type { Callable as CallableType } from '../createCallable/types.public'
 // consumer's static surface. These tests block that at compile time.
 
 describe('Callable<> shape', () => {
-  const Callable = createCallable<{ x: number }, boolean, { y: string }>(
+  const Confirm = createCallable<{ x: number }, boolean, { y: string }>(
     () => null,
   )
 
   test('exactly matches Callable<P, R, RP>', () => {
-    expectTypeOf(Callable).toEqualTypeOf<
-      CallableType<{ x: number }, boolean, { y: string }>
+    expectTypeOf(Confirm).toEqualTypeOf<
+      Callable<{ x: number }, boolean, { y: string }>
     >()
   })
 
   test('call: (props: Props) => Promise<Response>', () => {
-    expectTypeOf(Callable.call).toEqualTypeOf<
+    expectTypeOf(Confirm.call).toEqualTypeOf<
       (props: { x: number }) => Promise<boolean>
     >()
   })
 
   test('upsert: (props: Props) => Promise<Response>', () => {
-    expectTypeOf(Callable.upsert).toEqualTypeOf<
+    expectTypeOf(Confirm.upsert).toEqualTypeOf<
       (props: { x: number }) => Promise<boolean>
     >()
   })
 
   test('end accepts both targeted and untargeted forms', () => {
     // Targeted form: end(promise, response)
-    expectTypeOf(Callable.end)
+    expectTypeOf(Confirm.end)
       .parameter(0)
       .toEqualTypeOf<Promise<boolean> | boolean>()
     // The two overloads collapse to either:
@@ -45,14 +45,14 @@ describe('Callable<> shape', () => {
     //   [boolean]                    (untargeted)
     // Each individual call must satisfy ONE of them — type below ensures
     // the function accepts both shapes.
-    Callable.end(true)
-    Callable.end(Promise.resolve(true), false)
+    Confirm.end(true)
+    Confirm.end(Promise.resolve(true), false)
   })
 
   test('update accepts both targeted and untargeted forms', () => {
-    Callable.update({ x: 1 })
-    Callable.update(Promise.resolve(true), { x: 2 })
-    expectTypeOf(Callable.update)
+    Confirm.update({ x: 1 })
+    Confirm.update(Promise.resolve(true), { x: 2 })
+    expectTypeOf(Confirm.update)
       .parameter(0)
       .toEqualTypeOf<Promise<boolean> | Partial<{ x: number }>>()
   })
@@ -62,9 +62,7 @@ describe('Callable<> shape', () => {
     // backwards compatibility. This assertion documents that the
     // deprecated property is still a typed-correctly part of the
     // public API — do not delete thinking it covers dead code.
-    expectTypeOf(Callable.Root).toEqualTypeOf<
-      FunctionComponent<{ y: string }>
-    >()
+    expectTypeOf(Confirm.Root).toEqualTypeOf<FunctionComponent<{ y: string }>>()
   })
 })
 
@@ -95,7 +93,7 @@ describe('createCallable generic defaults', () => {
       () => null,
     )
     expectTypeOf(Explicit).toEqualTypeOf<
-      CallableType<{ msg: string }, number, { name: string }>
+      Callable<{ msg: string }, number, { name: string }>
     >()
   })
 })

--- a/packages/react-call/src/__tests__/callable-types.test.ts
+++ b/packages/react-call/src/__tests__/callable-types.test.ts
@@ -1,7 +1,7 @@
 import type { FunctionComponent } from 'react'
 import { describe, expectTypeOf, test } from 'vitest'
 import { createCallable } from '../createCallable'
-import type * as ReactCall from '../types.public'
+import type { Callable as CallableType } from '../createCallable/types.public'
 
 // Type-level pins for the shape of what `createCallable()` returns
 // (`Callable<>`) and for the generic-default behaviour of `createCallable`
@@ -17,9 +17,9 @@ describe('Callable<> shape', () => {
     () => null,
   )
 
-  test('exactly matches ReactCall.Callable<P, R, RP>', () => {
+  test('exactly matches Callable<P, R, RP>', () => {
     expectTypeOf(Callable).toEqualTypeOf<
-      ReactCall.Callable<{ x: number }, boolean, { y: string }>
+      CallableType<{ x: number }, boolean, { y: string }>
     >()
   })
 
@@ -95,7 +95,7 @@ describe('createCallable generic defaults', () => {
       () => null,
     )
     expectTypeOf(Explicit).toEqualTypeOf<
-      ReactCall.Callable<{ msg: string }, number, { name: string }>
+      CallableType<{ msg: string }, number, { name: string }>
     >()
   })
 })

--- a/packages/react-call/src/__tests__/exit-animations.test.tsx
+++ b/packages/react-call/src/__tests__/exit-animations.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { describe, expect, test } from 'vitest'
 import { createCallable } from '../createCallable'
-import type * as ReactCall from '../types.public'
+import type { UserComponent } from '../createCallable/types.public'
 import { withAct } from './shared/act'
 
 // The README documents that `unmountingDelay` keeps a finished call in the
@@ -17,7 +17,7 @@ const UNMOUNTING_DELAY = 50
 
 type Props = { message: string }
 
-const SlowConfirmComponent: ReactCall.UserComponent<Props, boolean, {}> = ({
+const SlowConfirmComponent: UserComponent<Props, boolean, {}> = ({
   call,
   message,
 }) => (

--- a/packages/react-call/src/__tests__/isolation.test.tsx
+++ b/packages/react-call/src/__tests__/isolation.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 import { createCallable } from '../createCallable'
-import type * as ReactCall from '../types.public'
+import type { UserComponent } from '../createCallable/types.public'
 import { withAct } from './shared/act'
 
 // Each createCallable() invocation builds an independent store. This
@@ -18,7 +18,7 @@ import { withAct } from './shared/act'
 type Props = { message: string }
 
 const dialog =
-  (instanceLabel: string): ReactCall.UserComponent<Props, void, {}> =>
+  (instanceLabel: string): UserComponent<Props, void, {}> =>
   ({ call, message }) => (
     <div
       role="dialog"

--- a/packages/react-call/src/__tests__/mutation-flow.test.tsx
+++ b/packages/react-call/src/__tests__/mutation-flow.test.tsx
@@ -3,7 +3,7 @@ import { useId } from 'react'
 import { describe, expect, test, vi } from 'vitest'
 import { createCallable } from '../createCallable'
 import { type MutationFn, useMutationFlow } from '../mutation-flow'
-import type * as ReactCall from '../types.public'
+import type { UserComponent } from '../createCallable/types.public'
 import { withAct } from './shared/act'
 
 // Component fixtures cover the three consumer patterns:
@@ -14,11 +14,10 @@ import { withAct } from './shared/act'
 
 type RequiredProps = { mutationFn: MutationFn<boolean> }
 
-const RequiredComponent: ReactCall.UserComponent<
-  RequiredProps,
-  boolean,
-  {}
-> = ({ call, mutationFn }) => {
+const RequiredComponent: UserComponent<RequiredProps, boolean, {}> = ({
+  call,
+  mutationFn,
+}) => {
   const a11yId = useId()
   const submit = useMutationFlow(call, mutationFn)
   return (
@@ -48,11 +47,10 @@ const Required = createCallable(RequiredComponent)
 
 type OptionalProps = { mutationFn?: MutationFn<boolean> }
 
-const OptionalComponent: ReactCall.UserComponent<
-  OptionalProps,
-  boolean,
-  {}
-> = ({ call, mutationFn }) => {
+const OptionalComponent: UserComponent<OptionalProps, boolean, {}> = ({
+  call,
+  mutationFn,
+}) => {
   const submit = useMutationFlow(call, mutationFn)
   return (
     <button
@@ -71,7 +69,7 @@ const Optional = createCallable(OptionalComponent)
 
 type PayloadProps = { mutationFn: MutationFn<string, { choice: 'A' | 'B' }> }
 
-const PayloadComponent: ReactCall.UserComponent<PayloadProps, string, {}> = ({
+const PayloadComponent: UserComponent<PayloadProps, string, {}> = ({
   call,
   mutationFn,
 }) => {
@@ -94,7 +92,7 @@ type PickerProps = {
   mutationFn?: MutationFn<'A' | 'B', { choice: 'A' | 'B' }>
 }
 
-const PickerComponent: ReactCall.UserComponent<PickerProps, 'A' | 'B', {}> = ({
+const PickerComponent: UserComponent<PickerProps, 'A' | 'B', {}> = ({
   call,
   mutationFn,
 }) => {
@@ -115,11 +113,10 @@ const Picker = createCallable(PickerComponent)
 
 type ManualCloseProps = { mutationFn?: MutationFn<boolean> }
 
-const ManualCloseComponent: ReactCall.UserComponent<
-  ManualCloseProps,
-  boolean,
-  {}
-> = ({ call, mutationFn }) => {
+const ManualCloseComponent: UserComponent<ManualCloseProps, boolean, {}> = ({
+  call,
+  mutationFn,
+}) => {
   const submit = useMutationFlow(call, mutationFn)
   return (
     <div role="dialog">

--- a/packages/react-call/src/__tests__/root-props.test.tsx
+++ b/packages/react-call/src/__tests__/root-props.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 import { createCallable } from '../createCallable'
-import type * as ReactCall from '../types.public'
+import type { UserComponent } from '../createCallable/types.public'
 import { withAct } from './shared/act'
 
 // Fixture purpose-built for the Root-props contract: the third generic
@@ -12,7 +12,7 @@ import { withAct } from './shared/act'
 type Props = { message: string }
 type RootProps = { userName: string }
 
-const GreeterComponent: ReactCall.UserComponent<Props, void, RootProps> = ({
+const GreeterComponent: UserComponent<Props, void, RootProps> = ({
   call,
   message,
 }) => (

--- a/packages/react-call/src/__tests__/shared/Confirm.tsx
+++ b/packages/react-call/src/__tests__/shared/Confirm.tsx
@@ -1,10 +1,10 @@
 import { useId } from 'react'
 import { createCallable } from '../../createCallable'
-import type * as ReactCall from '../../types.public'
+import type { UserComponent } from '../../createCallable/types.public'
 
 type Props = { message: string }
 
-export const ConfirmComponent: ReactCall.UserComponent<Props, boolean, {}> = ({
+export const ConfirmComponent: UserComponent<Props, boolean, {}> = ({
   call,
   message,
 }) => {

--- a/packages/react-call/src/__tests__/types.test.ts
+++ b/packages/react-call/src/__tests__/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, test } from 'vitest'
-import type * as ReactCall from '../types.public'
+import type { CallContext } from '../createCallable/types.public'
 
 // Regression guard for the CallContext leak that shipped in 1.8.x:
 // `CallContext` was defined as `Omit<PrivateCallContext, 'props'>`, a
@@ -10,7 +10,7 @@ import type * as ReactCall from '../types.public'
 // pin that contract so a future refactor cannot accidentally re-leak
 // the internals through type widening.
 
-type Ctx = ReactCall.Context<{ message: string }, boolean, { userName: string }>
+type Ctx = CallContext<{ message: string }, boolean, { userName: string }>
 
 // vitest 4 / expect-type requires a runtime value argument; the cast is
 // a placeholder — expectTypeOf only inspects the static type. An empty

--- a/packages/react-call/src/main.ts
+++ b/packages/react-call/src/main.ts
@@ -1,2 +1,9 @@
 export { createCallable } from './createCallable'
-export type * as ReactCall from './types.public'
+export type {
+  CallFunction,
+  UpsertFunction,
+  CallContext,
+  PropsWithCall,
+  UserComponent,
+  Callable,
+} from './createCallable/types.public'

--- a/packages/react-call/src/types.public.ts
+++ b/packages/react-call/src/types.public.ts
@@ -1,8 +1,0 @@
-export type {
-  CallFunction as Function,
-  UpsertFunction,
-  CallContext as Context,
-  PropsWithCall as Props,
-  UserComponent,
-  Callable,
-} from './createCallable/types.public'


### PR DESCRIPTION
## Summary

- Public types of the main entry are now flat named exports (`CallFunction`, `UpsertFunction`, `CallContext`, `PropsWithCall`, `UserComponent`, `Callable`) instead of `export type * as ReactCall`. See [ADR-0015](docs/adr/0015-flat-type-exports-over-namespace.md) for the rationale.
- Aligns the main entry with the `react-call/mutation-flow` subpath (which already used flat exports) and with the broader React/TS ecosystem convention.
- Hard break under the ADR-0003 umbrella: no `@deprecated` alias. The renaming layer `src/types.public.ts` is deleted; `src/main.ts` re-exports directly from `createCallable/types.public`.

Migration is a mechanical find-and-replace for consumers:

| Before | After |
| --- | --- |
| `ReactCall.Function` | `CallFunction` |
| `ReactCall.UpsertFunction` | `UpsertFunction` |
| `ReactCall.Context` | `CallContext` |
| `ReactCall.Props` | `PropsWithCall` |
| `ReactCall.UserComponent` | `UserComponent` |
| `ReactCall.Callable` | `Callable` |

No runtime change — types are erased at compile time. JS bundle is byte-identical.

## Test plan

- [x] `pnpm -F react-call check:types` — `tsc --noEmit` passes
- [x] `pnpm exec vitest run --project=unit` — 82/82 unit tests pass
- [x] Lefthook pre-commit (lint + typecheck) passes
- [ ] CI green on the PR