### PR TITLE
docs: redesign README header and spotlight the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <div align="center">
   <h2>
     ⚛️ 📡 <a href="https://react-call.desko.dev">react-call</a>
-    <a href="https://www.npmjs.com/package/react-call"><img src="https://img.shields.io/npm/dw/react-call?style=flat&label=npm&color=blue" alt="NPM Downloads"></a>
+    <a href="https://www.npmjs.com/package/react-call"><img src="https://img.shields.io/npm/v/react-call?style=flat&label=npm&color=blue" alt="NPM Version"></a>
+    <a href="https://www.npmjs.com/package/react-call"><img src="https://img.shields.io/npm/dw/react-call?style=flat&label=downloads&color=blue" alt="NPM Downloads"></a>
     <a href="https://bundlephobia.com/package/react-call"><img src="https://img.shields.io/bundlephobia/minzip/react-call?style=flat&label=size&color=blue" alt="Bundle size"></a>
   </h2>
   ✓ 1 KB ✓ No deps ✓ SSR ✓ React Native

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
-  <h2>
+  <h1>
     ⚛️ 📡 <a href="https://react-call.desko.dev">react-call</a>
-  </h2>
+  </h1>
 
   <p><em>Call your React components like async functions — they resolve with a value.</em></p>
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@
   </p>
 </div>
 
-> [!NOTE]
-> These docs cover **v2**, the current stable release. Upgrading from 1.x? See [Migrating from v1](#migrating-from-v1) — or the [v1 README](https://github.com/desko27/react-call/blob/react-call%401.8.2/README.md) for the old API.
-
 `createCallable()` turns a React component into something you can `await`.
 
 Good fits: confirmations, dialogs, form modals, toasts, notifications, context
@@ -70,6 +67,9 @@ menus, pickers — any UI that conceptually returns a value to its caller.
 - [Migrating from v1](#migrating-from-v1)
 
 # Getting started
+
+> [!NOTE]
+> These docs cover **v2**, the current stable release. Upgrading from 1.x? See [Migrating from v1](#migrating-from-v1) — or the [v1 README](https://github.com/desko27/react-call/blob/react-call%401.8.2/README.md) for the old API.
 
 ```sh
 npm install react-call

--- a/README.md
+++ b/README.md
@@ -1,12 +1,26 @@
 <div align="center">
   <h2>
     ⚛️ 📡 <a href="https://react-call.desko.dev">react-call</a>
+  </h2>
+
+  <p><em>Call your React components like async functions — they resolve with a value.</em></p>
+
+  <p>
     <a href="https://www.npmjs.com/package/react-call"><img src="https://img.shields.io/npm/v/react-call?style=flat&label=npm&color=blue" alt="NPM Version"></a>
     <a href="https://www.npmjs.com/package/react-call"><img src="https://img.shields.io/npm/dw/react-call?style=flat&label=downloads&color=blue" alt="NPM Downloads"></a>
     <a href="https://bundlephobia.com/package/react-call"><img src="https://img.shields.io/bundlephobia/minzip/react-call?style=flat&label=size&color=blue" alt="Bundle size"></a>
-  </h2>
-  ✓ 1 KB ✓ No deps ✓ SSR ✓ React Native
-  <p>— Call your React components —</p>
+    <a href="https://www.npmjs.com/package/react-call"><img src="https://img.shields.io/npm/l/react-call?style=flat&label=license&color=blue" alt="License"></a>
+  </p>
+
+  ✓ &lt; 1 KB ✓ No deps ✓ SSR ✓ React Native
+
+  <p>
+    <strong><a href="https://react-call.desko.dev">📖 Site with live demos&nbsp;↗</a></strong>
+    &nbsp;·&nbsp;
+    <a href="https://react-call.desko.dev/examples">Examples gallery</a>
+    &nbsp;·&nbsp;
+    <a href="#getting-started">Getting started</a>
+  </p>
 </div>
 
 > [!NOTE]
@@ -18,7 +32,11 @@ Good fits: confirmations, dialogs, form modals, toasts, notifications, context
 menus, pickers — any UI that conceptually returns a value to its caller.
 
 
-![Hero](./docs/assets/hero.png)
+<p align="center">
+  <a href="https://react-call.desko.dev">
+    <img alt="react-call — call your React components" src="./docs/assets/hero.png" />
+  </a>
+</p>
 
 ## Contents
 
@@ -96,7 +114,7 @@ You're all done! Now you can do this anywhere in your codebase:
 const accepted = await Confirm.call({ message: 'Continue?' })
 ```
 
-Check out [the demo site](https://react-call.desko.dev/) to see some live examples of other React components being called.
+Want to see more? The [**examples gallery**](https://react-call.desko.dev/examples) has live demos of confirm dialogs, command palettes, toasts, multi-step wizards, drawers and more — each with its source and an **Open in CodeSandbox** button.
 
 # Advanced usage
 


### PR DESCRIPTION
## What

A focused pass over the top of the README — badges, header layout, and giving the new site the prominence it deserves.

### Changes
- **npm version badge** added (label `npm`); existing downloads badge relabeled to `downloads` for clarity.
- **Header redesign**: title promoted to `h1` (it was `h2`, smaller than the section headings), badges moved to their own row, license badge added, descriptive tagline, and a nav row linking the site / examples gallery / getting started.
- **Hero image** now links to the site.
- **v2 migration note** moved out of the lede (it was splitting the title from the pitch) down to `# Getting started`, where the version context is actionable.
- **Examples mention** rewritten to point at the gallery with concrete demos + the "Open in CodeSandbox" affordance.

The `⚛️ 📡` emojis in the title are kept on purpose — they mirror the **Declare** and **Root** step icons, so the title previews the tutorial.

## Verification
Rendered the README through the GitHub markdown API (dark theme, GitHub's own CSS) to confirm layout at each step rather than eyeballing the source.

> Note: the license badge briefly showed "rate limited by upstream service" in local renders — that's shields.io throttling repeated local fetches, not a README issue. On GitHub it's served cached via camo and shows **MIT**.

## Commits
- `db1d07b` docs: add npm version badge to README header
- `1577f31` docs: redesign README header and spotlight the site
- `8bd5ac0` docs: move v2 note out of the README lede
- `9f31000` docs: bump README title to h1