### PR TITLE
feat(web): fill example-gallery gaps for uncovered library features

### DIFF
--- a/sites/web/src/components/gallery/Gallery.tsx
+++ b/sites/web/src/components/gallery/Gallery.tsx
@@ -94,9 +94,6 @@ export const Gallery = ({ entries }: Props) => {
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
-          <span className="font-mono text-xs uppercase tracking-wider text-[var(--color-fg-subtle)]">
-            Behaviors
-          </span>
           {ALL_BEHAVIORS.map((b) => (
             <BehaviorPill
               key={b}

--- a/sites/web/src/components/gallery/PlaygroundButton.tsx
+++ b/sites/web/src/components/gallery/PlaygroundButton.tsx
@@ -7,6 +7,7 @@ interface Props {
   callableSource: string
   callerFilename: string
   callerSource: string
+  rootProps?: string
 }
 
 const exportNameFromSource = (source: string, fallback: string): string => {
@@ -95,14 +96,18 @@ root.render(
 )
 `
 
-const buildApp = (callableExport: string, callerExport: string) =>
+const buildApp = (
+  callableExport: string,
+  callerExport: string,
+  rootProps?: string,
+) =>
   `import { ${callableExport} } from './Callable'
 import { ${callerExport} } from './Caller'
 
 export default function App() {
   return (
     <>
-      <${callableExport} />
+      <${callableExport}${rootProps ? ` ${rootProps}` : ''} />
       <${callerExport} />
     </>
   )
@@ -167,6 +172,7 @@ export const PlaygroundButton = ({
   callableSource,
   callerFilename,
   callerSource,
+  rootProps,
 }: Props) => {
   const [opening, setOpening] = useState(false)
 
@@ -181,7 +187,9 @@ export const PlaygroundButton = ({
         'tsconfig.json': { content: TSCONFIG },
         'public/index.html': { content: PUBLIC_INDEX_HTML },
         'src/index.tsx': { content: INDEX_TSX },
-        'src/App.tsx': { content: buildApp(callableExport, callerExport) },
+        'src/App.tsx': {
+          content: buildApp(callableExport, callerExport, rootProps),
+        },
         'src/Callable.tsx': { content: callableSource },
         'src/Caller.tsx': {
           content: rewriteCallerImports(callerSource, 'Callable'),

--- a/sites/web/src/examples/bottom-sheet/callable.tsx
+++ b/sites/web/src/examples/bottom-sheet/callable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createCallable } from 'react-call'
 
 interface Action {
@@ -12,9 +12,22 @@ interface Props {
   actions: readonly Action[]
 }
 
+// Keep the finished call mounted long enough for the slide-down to play.
+// Must match the CSS transition duration below.
+const UNMOUNTING_DELAY = 300
+
 export const BottomSheet = createCallable<Props, string | null>(
   ({ call, title, actions }) => {
     const sheetRef = useRef<HTMLDivElement>(null)
+
+    // Animate in on mount, out once the call has ended. `call.ended` is
+    // true during the unmounting delay — that's the window the exit
+    // transition plays in before react-call drops the call from the stack.
+    // The flag flips in an effect (post-paint), so the browser commits the
+    // off-screen state first and the slide-up has somewhere to animate from.
+    const [entered, setEntered] = useState(false)
+    useEffect(() => setEntered(true), [])
+    const open = entered && !call.ended
 
     useEffect(() => {
       const onPointer = (e: MouseEvent) => {
@@ -38,11 +51,11 @@ export const BottomSheet = createCallable<Props, string | null>(
         role="dialog"
         aria-modal="true"
         aria-label={title}
-        className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 backdrop-blur-sm"
+        className={`fixed inset-0 z-50 flex items-end justify-center bg-black/50 backdrop-blur-sm transition-opacity duration-300 ${open ? 'opacity-100' : 'opacity-0'}`}
       >
         <div
           ref={sheetRef}
-          className="w-full max-w-md rounded-t-2xl border-t border-x border-[var(--color-border)] bg-[var(--color-bg)] p-4 shadow-2xl"
+          className={`w-full max-w-md rounded-t-2xl border-t border-x border-[var(--color-border)] bg-[var(--color-bg)] p-4 shadow-2xl transition-transform duration-300 ease-out ${open ? 'translate-y-0' : 'translate-y-full'}`}
         >
           <div
             aria-hidden="true"
@@ -69,5 +82,6 @@ export const BottomSheet = createCallable<Props, string | null>(
       </div>
     )
   },
+  UNMOUNTING_DELAY,
 )
 BottomSheet.displayName = 'BottomSheet'

--- a/sites/web/src/examples/bottom-sheet/meta.ts
+++ b/sites/web/src/examples/bottom-sheet/meta.ts
@@ -3,9 +3,9 @@ import type { ExampleMeta } from '~/lib/examples'
 export const meta = {
   title: 'Bottom sheet',
   description:
-    'Slides up from the bottom — the mobile-native pattern for action menus and quick choices.',
+    'Slides up from the bottom and back down on close — the mobile-native pattern for action menus and quick choices.',
   category: 'drawer',
-  behaviors: [],
+  behaviors: ['exit-animation'],
   tags: ['mobile', 'actions'],
   files: { callable: 'BottomSheet.tsx', caller: 'ShareButton.tsx' },
   order: 40,

--- a/sites/web/src/examples/bottom-sheet/notes.mdx
+++ b/sites/web/src/examples/bottom-sheet/notes.mdx
@@ -1,0 +1,19 @@
+## The slide-down on close
+
+The sheet would pop out of existence the moment `call.end()` runs, with no
+chance to slide away. Passing an **unmounting delay** (the second argument
+to `createCallable`) keeps the finished call mounted for that many
+milliseconds and exposes `call.ended` so you can drive the exit:
+
+```tsx
+const open = entered && !call.ended
+// open ? 'translate-y-0' : 'translate-y-full'
+```
+
+One `open` flag runs both halves: it flips on the first frame after mount
+(slide up), and back to `false` when `call.ended` turns true (slide down),
+right before react-call drops the call from the stack.
+
+Keep the delay equal to the CSS transition duration — here both are
+`300ms`. See the [settings drawer](/examples/side-drawer) for the same
+pattern on a horizontal slide.

--- a/sites/web/src/examples/broadcast-update/callable.tsx
+++ b/sites/web/src/examples/broadcast-update/callable.tsx
@@ -1,0 +1,47 @@
+import { createCallable } from 'react-call'
+
+type UploadState = 'uploading' | 'paused' | 'done'
+
+interface Props {
+  label: string
+  state: UploadState
+}
+
+const ROW_HEIGHT = 52 // px per stacked pill, including gap
+
+const STATE_META: Record<UploadState, { icon: string; text: string }> = {
+  uploading: { icon: '↑', text: 'uploading…' },
+  paused: { icon: '⏸', text: 'paused' },
+  done: { icon: '✓', text: 'done' },
+}
+
+export const Upload = createCallable<Props, void>(({ call, label, state }) => {
+  // call.index is this call's slot in the stack — offset each pill upward
+  // so concurrent uploads stack instead of overlapping.
+  const bottom = 24 + call.index * ROW_HEIGHT
+  const { icon, text } = STATE_META[state]
+
+  return (
+    <div
+      style={{ bottom }}
+      className="pointer-events-none fixed right-6 z-50 transition-[bottom] duration-200"
+    >
+      <div className="pointer-events-auto flex w-72 items-center gap-3 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-2 text-sm text-[var(--color-fg)] shadow-2xl backdrop-blur">
+        <span aria-hidden="true">{icon}</span>
+        <span className="flex-1 truncate">{label}</span>
+        <span className="font-mono text-xs text-[var(--color-fg-subtle)]">
+          {text}
+        </span>
+        <button
+          type="button"
+          onClick={() => call.end()}
+          aria-label="Dismiss"
+          className="-mr-1 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-base leading-none text-[var(--color-fg-subtle)] transition-colors hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-fg)]"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  )
+})
+Upload.displayName = 'Upload'

--- a/sites/web/src/examples/broadcast-update/caller.tsx
+++ b/sites/web/src/examples/broadcast-update/caller.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import { Upload } from './callable'
+
+const FILES = ['report.pdf', 'photo.jpg', 'archive.zip']
+
+export const UploadQueueButton = () => {
+  const [online, setOnline] = useState(true)
+  const [openCount, setOpenCount] = useState(0)
+
+  const start = () => {
+    setOnline(true)
+    for (const label of FILES) {
+      // The promise resolves when this pill is dismissed (× → call.end()),
+      // so we can track how many are still open and re-enable Start at zero.
+      const promise = Upload.call({ label, state: 'uploading' })
+      setOpenCount((n) => n + 1)
+      promise.then(() => setOpenCount((n) => n - 1))
+    }
+  }
+
+  // One update() with no promise broadcasts to EVERY open call. It merges
+  // `state` into each pill's props, so they all flip together while each
+  // keeps its own `label`.
+  const toggleConnection = () => {
+    const next = !online
+    setOnline(next)
+    Upload.update({ state: next ? 'uploading' : 'paused' })
+  }
+
+  const completeAll = () => {
+    setOnline(true)
+    Upload.update({ state: 'done' })
+  }
+
+  const idle = openCount === 0
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="flex flex-wrap justify-center gap-3">
+        <button
+          type="button"
+          onClick={start}
+          disabled={!idle}
+          className="rounded-md bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--color-accent-hover)] disabled:opacity-50"
+        >
+          Start 3 uploads
+        </button>
+        <button
+          type="button"
+          onClick={toggleConnection}
+          disabled={idle}
+          className="rounded-md border border-[var(--color-border)] px-4 py-2 text-sm font-medium text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)] disabled:opacity-50"
+        >
+          Toggle connection
+        </button>
+        <button
+          type="button"
+          onClick={completeAll}
+          disabled={idle}
+          className="rounded-md border border-[var(--color-border)] px-4 py-2 text-sm font-medium text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)] disabled:opacity-50"
+        >
+          Complete all
+        </button>
+      </div>
+      <span className="font-mono text-xs text-[var(--color-fg-subtle)]">
+        {idle
+          ? '→ start some uploads, then broadcast to all of them'
+          : `connection: ${online ? 'online' : 'offline'} — ${openCount} open`}
+      </span>
+    </div>
+  )
+}

--- a/sites/web/src/examples/broadcast-update/index.tsx
+++ b/sites/web/src/examples/broadcast-update/index.tsx
@@ -1,0 +1,11 @@
+import { Upload } from './callable'
+import { UploadQueueButton } from './caller'
+
+const BroadcastUpdateExample = () => (
+  <>
+    <Upload />
+    <UploadQueueButton />
+  </>
+)
+
+export default BroadcastUpdateExample

--- a/sites/web/src/examples/broadcast-update/meta.ts
+++ b/sites/web/src/examples/broadcast-update/meta.ts
@@ -1,0 +1,12 @@
+import type { ExampleMeta } from '~/lib/examples'
+
+export const meta = {
+  title: 'Broadcast to every call',
+  description:
+    'Several upload pills stacked at once. One Upload.update(props) with no promise merges into every open call, so a single connection change flips them all — while each keeps its own filename.',
+  category: 'notification',
+  behaviors: ['update', 'stacking'],
+  tags: ['broadcast', 'status', 'stack'],
+  files: { callable: 'Upload.tsx', caller: 'UploadQueueButton.tsx' },
+  order: 13,
+} satisfies ExampleMeta

--- a/sites/web/src/examples/broadcast-update/notes.mdx
+++ b/sites/web/src/examples/broadcast-update/notes.mdx
@@ -1,0 +1,27 @@
+## Update without a promise hits everyone
+
+`update` has two forms. Pass a promise to target one call; omit it and the
+new props **broadcast to every open call**:
+
+```tsx
+Upload.update({ state: 'paused' }) // every open pill, at once
+```
+
+It's a shallow **merge**, not a replace — `state` lands on each call while
+its own `label` stays put. That's why one "connection lost" event can
+pause three uploads without the caller tracking a single promise.
+
+## Broadcast vs. targeted
+
+This is the counterpart to [Live status](/examples/live-status):
+
+- **Targeted** — `update(promise, props)` pushes to one specific call the
+  caller is tracking. Use it when each call has its own lifecycle.
+- **Broadcast** — `update(props)` pushes to all of them. Use it for
+  ambient state every open call should reflect: connectivity, a global
+  mode, a shared clock.
+
+## Gotchas
+
+- Merging means a partial broadcast leaves untouched props alone — handy,
+  but double-check you're not relying on a prop a stale call still holds.

--- a/sites/web/src/examples/caller-resolve/callable.tsx
+++ b/sites/web/src/examples/caller-resolve/callable.tsx
@@ -1,0 +1,38 @@
+import { createCallable } from 'react-call'
+
+interface Props {
+  action: string
+}
+type Response = boolean
+
+export const Approval = createCallable<Props, Response>(({ call, action }) => (
+  <div
+    role="dialog"
+    aria-modal="true"
+    className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+  >
+    <div className="w-full max-w-sm rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-6 shadow-2xl">
+      <p className="text-base text-[var(--color-fg)]">Approve: {action}?</p>
+      <p className="mt-1 text-xs text-[var(--color-fg-subtle)]">
+        Auto-declines from the caller if you don't respond in time.
+      </p>
+      <div className="mt-6 flex items-center justify-end gap-3">
+        <button
+          type="button"
+          onClick={() => call.end(false)}
+          className="rounded-md border border-[var(--color-border)] px-4 py-2 text-sm font-medium text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]"
+        >
+          Decline
+        </button>
+        <button
+          type="button"
+          onClick={() => call.end(true)}
+          className="rounded-md bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--color-accent-hover)]"
+        >
+          Approve
+        </button>
+      </div>
+    </div>
+  </div>
+))
+Approval.displayName = 'Approval'

--- a/sites/web/src/examples/caller-resolve/caller.tsx
+++ b/sites/web/src/examples/caller-resolve/caller.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react'
+import { Approval } from './callable'
+
+const TIMEOUT_SECONDS = 4
+
+export const RequestApprovalButton = () => {
+  const [status, setStatus] = useState<string>('→ no request yet')
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(null)
+
+  const handleClick = async () => {
+    setStatus('awaiting approval…')
+
+    // The promise returned by call() IS the call's identity. Hold it so
+    // the timeout can settle THIS specific open call from out here.
+    const promise = Approval.call({ action: 'Deploy to production' })
+
+    let answered = false
+    promise.then(() => {
+      answered = true
+    })
+
+    // A plain caller-side countdown — no update() needed, it's local UI.
+    let left = TIMEOUT_SECONDS
+    setSecondsLeft(left)
+    const ticker = setInterval(() => {
+      left -= 1
+      setSecondsLeft(left > 0 ? left : null)
+      if (left <= 0) clearInterval(ticker)
+    }, 1000)
+
+    let timedOut = false
+    const timer = setTimeout(() => {
+      if (answered) return
+      timedOut = true
+      // End the call from caller scope, delivering a Response value.
+      // Targeted at `promise`, so only this call is settled.
+      Approval.end(promise, false)
+    }, TIMEOUT_SECONDS * 1000)
+
+    const approved = await promise
+    clearTimeout(timer)
+    clearInterval(ticker)
+    setSecondsLeft(null)
+    setStatus(
+      approved
+        ? '→ approved'
+        : timedOut
+          ? '→ auto-declined (timed out)'
+          : '→ declined',
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={secondsLeft !== null}
+        className="rounded-md bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--color-accent-hover)] disabled:opacity-50"
+      >
+        Request approval
+      </button>
+      <span className="font-mono text-xs text-[var(--color-fg-subtle)]">
+        {secondsLeft !== null ? (
+          <span className="text-[var(--color-accent)]">
+            auto-declines in {secondsLeft}s…
+          </span>
+        ) : (
+          status
+        )}
+      </span>
+    </div>
+  )
+}

--- a/sites/web/src/examples/caller-resolve/index.tsx
+++ b/sites/web/src/examples/caller-resolve/index.tsx
@@ -1,0 +1,11 @@
+import { Approval } from './callable'
+import { RequestApprovalButton } from './caller'
+
+const CallerResolveExample = () => (
+  <>
+    <Approval />
+    <RequestApprovalButton />
+  </>
+)
+
+export default CallerResolveExample

--- a/sites/web/src/examples/caller-resolve/meta.ts
+++ b/sites/web/src/examples/caller-resolve/meta.ts
@@ -1,0 +1,12 @@
+import type { ExampleMeta } from '~/lib/examples'
+
+export const meta = {
+  title: 'Resolve from the caller',
+  description:
+    "The promise from call() is the call's identity. A timeout in the caller settles that exact open call from the outside with Approval.end(promise, false) — delivering a response without any in-dialog click.",
+  category: 'flow',
+  behaviors: ['end-from-caller'],
+  tags: ['timeout', 'external', 'promise'],
+  files: { callable: 'Approval.tsx', caller: 'RequestApprovalButton.tsx' },
+  order: 62,
+} satisfies ExampleMeta

--- a/sites/web/src/examples/caller-resolve/notes.mdx
+++ b/sites/web/src/examples/caller-resolve/notes.mdx
@@ -1,0 +1,35 @@
+## The promise is the call
+
+`Approval.call(...)` returns a promise that's both the awaited response
+**and** a handle to that specific open call. Pass it back to
+`Approval.end(promise, value)` and you settle that call from anywhere —
+here, a `setTimeout` that auto-declines if the user goes quiet:
+
+```tsx
+const promise = Approval.call({ action: 'Deploy to production' })
+setTimeout(() => Approval.end(promise, false), 4000)
+const approved = await promise // resolves whoever wins: user or timeout
+```
+
+Whether the user clicks a button (`call.end` inside) or the timeout fires
+(`Approval.end` outside), the same promise resolves and the dialog closes.
+
+## Targeted vs. all
+
+Pass the promise to hit **one** call. Omit it to end **every** open call
+at once, with one response value:
+
+```tsx
+Approval.end(false) // decline all open approvals
+```
+
+Useful for a global "cancel everything" — a route change, a logout, a
+parent flow that's been abandoned.
+
+## Gotchas
+
+- **Ending a settled call is a no-op.** If the user answers first, the
+  later `Approval.end(promise, …)` does nothing — no need to cancel the
+  timer for correctness (we clear it anyway to stop the countdown).
+- This is the [update](/examples/live-status) story in reverse: there the
+  caller pushes new props into the open call; here it closes it.

--- a/sites/web/src/examples/optional-mutation/callable.tsx
+++ b/sites/web/src/examples/optional-mutation/callable.tsx
@@ -1,0 +1,48 @@
+import { createCallable } from 'react-call'
+import { type MutationFn, useMutationFlow } from 'react-call/mutation-flow'
+
+interface Props {
+  message: string
+  // Optional: type it as possibly-undefined to unlock `.orEnd(value)` at
+  // the callsite. Callers may pass an async handler or skip it entirely.
+  mutationFn?: MutationFn<boolean>
+}
+
+export const Confirm = createCallable<Props, boolean>(
+  ({ call, message, mutationFn }) => {
+    const submit = useMutationFlow(call, mutationFn)
+
+    return (
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      >
+        <div className="w-full max-w-sm rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-6 shadow-2xl">
+          <p className="text-base text-[var(--color-fg)]">{message}</p>
+          <div className="mt-6 flex items-center justify-end gap-3">
+            <button
+              type="button"
+              disabled={submit.pending}
+              onClick={() => call.end(false)}
+              className="rounded-md border border-[var(--color-border)] px-4 py-2 text-sm font-medium text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)] disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={submit.pending}
+              // No mutationFn → `.orEnd(true)` closes with the fallback.
+              // With one → `.orEnd` is a no-op; the handler closes instead.
+              onClick={() => submit().orEnd(true)}
+              className="rounded-md bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--color-accent-hover)] disabled:opacity-50"
+            >
+              {submit.pending ? 'Working…' : 'Confirm'}
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  },
+)
+Confirm.displayName = 'Confirm'

--- a/sites/web/src/examples/optional-mutation/caller.tsx
+++ b/sites/web/src/examples/optional-mutation/caller.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import { Confirm } from './callable'
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+export const PublishButton = () => {
+  const [status, setStatus] = useState<string>('→ awaiting click…')
+
+  // No mutationFn: `submit().orEnd(true)` closes the call instantly with
+  // the fallback response. A plain confirm — no async, no pending state.
+  const quickConfirm = async () => {
+    const ok = await Confirm.call({ message: 'Discard your draft?' })
+    setStatus(ok ? '→ draft discarded' : '→ kept')
+  }
+
+  // With a mutationFn: `.orEnd` becomes a no-op. The handler owns the
+  // close — pending shows while it runs, then it calls call.end(true).
+  const confirmAndPublish = async () => {
+    const ok = await Confirm.call({
+      message: 'Publish this post now?',
+      mutationFn: async (call) => {
+        await sleep(900)
+        call.end(true)
+      },
+    })
+    setStatus(ok ? '→ published' : '→ cancelled')
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={quickConfirm}
+          className="rounded-md border border-[var(--color-border)] px-4 py-2 text-sm font-medium text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]"
+        >
+          Discard draft
+        </button>
+        <button
+          type="button"
+          onClick={confirmAndPublish}
+          className="rounded-md bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--color-accent-hover)]"
+        >
+          Publish post
+        </button>
+      </div>
+      <span className="font-mono text-xs text-[var(--color-fg-subtle)]">
+        {status}
+      </span>
+    </div>
+  )
+}

--- a/sites/web/src/examples/optional-mutation/index.tsx
+++ b/sites/web/src/examples/optional-mutation/index.tsx
@@ -1,0 +1,11 @@
+import { Confirm } from './callable'
+import { PublishButton } from './caller'
+
+const OptionalMutationExample = () => (
+  <>
+    <Confirm />
+    <PublishButton />
+  </>
+)
+
+export default OptionalMutationExample

--- a/sites/web/src/examples/optional-mutation/meta.ts
+++ b/sites/web/src/examples/optional-mutation/meta.ts
@@ -1,0 +1,12 @@
+import type { ExampleMeta } from '~/lib/examples'
+
+export const meta = {
+  title: 'Confirm with optional async',
+  description:
+    'One Callable, two callers. Omit mutationFn and submit().orEnd(true) closes instantly with a fallback response; pass one and the async handler decides when to close — the same Confirm serves both.',
+  category: 'dialog',
+  behaviors: ['mutation-flow'],
+  tags: ['optional', 'orEnd', 'fallback'],
+  files: { callable: 'Confirm.tsx', caller: 'PublishButton.tsx' },
+  order: 7,
+} satisfies ExampleMeta

--- a/sites/web/src/examples/optional-mutation/notes.mdx
+++ b/sites/web/src/examples/optional-mutation/notes.mdx
@@ -1,0 +1,17 @@
+## One Callable, two close paths
+
+Typing `mutationFn?` as possibly-undefined changes what the trigger
+returns: instead of `void`, `submit()` hands back a chain object with
+`.orEnd(value)`. That one chain covers both callers:
+
+- **No handler** (the _Discard draft_ button) → `submit().orEnd(true)`
+  delivers the **fallback response** and closes the call right away. No
+  async, no pending — a plain confirm.
+- **With a handler** (the _Publish post_ button) → `.orEnd` is a **no-op**.
+  The MutationFn runs (pending flips true), then it calls `call.end(true)`.
+
+The Callable doesn't branch on which caller it's serving — `useMutationFlow`
+resolves it from whether `mutationFn` is present at runtime.
+
+See [Save form](/examples/save-form) for the required-handler case, where
+the dialog stays open on a thrown error so the user can retry.

--- a/sites/web/src/examples/root-context/callable.tsx
+++ b/sites/web/src/examples/root-context/callable.tsx
@@ -1,0 +1,46 @@
+import { createCallable } from 'react-call'
+
+interface Props {
+  message: string
+}
+type Response = boolean
+
+// The third generic is RootProps — what the Root mount accepts and what
+// each call reads via `call.root`. It's separate from the per-call Props.
+type RootProps = {
+  userName: string
+}
+
+export const Greeter = createCallable<Props, Response, RootProps>(
+  ({ call, message }) => (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+    >
+      <div className="w-full max-w-sm rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-6 shadow-2xl">
+        <p className="font-mono text-xs uppercase tracking-wider text-[var(--color-fg-subtle)]">
+          Signed in as {call.root.userName}
+        </p>
+        <p className="mt-2 text-base text-[var(--color-fg)]">{message}</p>
+        <div className="mt-6 flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={() => call.end(false)}
+            className="rounded-md border border-[var(--color-border)] px-4 py-2 text-sm font-medium text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]"
+          >
+            Not now
+          </button>
+          <button
+            type="button"
+            onClick={() => call.end(true)}
+            className="rounded-md bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--color-accent-hover)]"
+          >
+            Enable
+          </button>
+        </div>
+      </div>
+    </div>
+  ),
+)
+Greeter.displayName = 'Greeter'

--- a/sites/web/src/examples/root-context/caller.tsx
+++ b/sites/web/src/examples/root-context/caller.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import { Greeter } from './callable'
+
+export const AskButton = () => {
+  const [status, setStatus] = useState<'idle' | 'enabled' | 'dismissed'>('idle')
+
+  const handleClick = async () => {
+    // Note what the caller does NOT pass: the user's name. That lives on
+    // the Root and reaches the call through `call.root` — the caller only
+    // supplies the per-call message.
+    const enabled = await Greeter.call({
+      message: 'Enable two-factor authentication for your account?',
+    })
+    setStatus(enabled ? 'enabled' : 'dismissed')
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <button
+        type="button"
+        onClick={handleClick}
+        className="rounded-md bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--color-accent-hover)]"
+      >
+        Review security
+      </button>
+      <span className="font-mono text-xs text-[var(--color-fg-subtle)]">
+        {status === 'idle' && '→ awaiting click…'}
+        {status === 'enabled' && (
+          <span className="text-[var(--color-accent)]">→ 2FA enabled</span>
+        )}
+        {status === 'dismissed' && '→ dismissed'}
+      </span>
+    </div>
+  )
+}

--- a/sites/web/src/examples/root-context/index.tsx
+++ b/sites/web/src/examples/root-context/index.tsx
@@ -1,0 +1,12 @@
+import { Greeter } from './callable'
+import { AskButton } from './caller'
+
+const RootContextExample = () => (
+  <>
+    {/* The Root carries data every call can read via call.root. */}
+    <Greeter userName="Ada Lovelace" />
+    <AskButton />
+  </>
+)
+
+export default RootContextExample

--- a/sites/web/src/examples/root-context/meta.ts
+++ b/sites/web/src/examples/root-context/meta.ts
@@ -1,0 +1,13 @@
+import type { ExampleMeta } from '~/lib/examples'
+
+export const meta = {
+  title: 'Account-aware dialog',
+  description:
+    'A dialog that greets the signed-in user without the caller ever passing their name. The user lives on a Root prop and reaches every call through call.root — separate from the per-call props.',
+  category: 'dialog',
+  behaviors: ['root-props'],
+  tags: ['root-props', 'context', 'shared'],
+  files: { callable: 'Greeter.tsx', caller: 'AskButton.tsx' },
+  rootProps: 'userName="Ada Lovelace"',
+  order: 6,
+} satisfies ExampleMeta

--- a/sites/web/src/examples/root-context/notes.mdx
+++ b/sites/web/src/examples/root-context/notes.mdx
@@ -1,0 +1,30 @@
+## Two kinds of props
+
+A call has **per-call props** (passed at `Greeter.call({ message })`) and
+**Root props** (passed at the mount, `<Greeter userName="Ada Lovelace" />`).
+The third generic on `createCallable<Props, Response, RootProps>` types the
+latter, and every call reads them through `call.root`:
+
+```tsx
+<p>Signed in as {call.root.userName}</p>
+```
+
+The caller never forwards the user's name — it would be noise at every
+callsite. The Root holds it once; each call projects it.
+
+## When to reach for Root props
+
+- **Share one value with every call** — the current user, tenant, locale,
+  feature flags. Set it on the Root, read it from `call.root`.
+- **Surface something only the Root's parent has** — a theme object, a
+  router, anything in scope where you mount `<Greeter />` but not where
+  you call it.
+- **Push live data into open calls.** Root props are reactive: when the
+  Root re-renders with a new `userName`, every active call re-renders with
+  it too — no `update()` needed, because it isn't a per-call prop.
+
+## Per-call or Root prop?
+
+If the value changes per invocation (the message, the item being acted
+on), it's a **per-call prop**. If it's ambient — the same for every call
+and owned by the surrounding app — it's a **Root prop**.

--- a/sites/web/src/examples/side-drawer/callable.tsx
+++ b/sites/web/src/examples/side-drawer/callable.tsx
@@ -13,10 +13,23 @@ interface Props {
   initial: Settings
 }
 
+// Keep the finished call mounted long enough for the slide-out to play.
+// Must match the CSS transition duration below.
+const UNMOUNTING_DELAY = 300
+
 export const SettingsDrawer = createCallable<Props, Settings | null>(
   ({ call, initial }) => {
     const drawerRef = useRef<HTMLDivElement>(null)
     const [settings, setSettings] = useState<Settings>(initial)
+
+    // Animate in on mount, out once the call has ended. `call.ended` is
+    // true during the unmounting delay — that's the window the exit
+    // transition plays in before react-call drops the call from the stack.
+    // The flag flips in an effect (post-paint), so the browser commits the
+    // off-screen state first and the slide-in has somewhere to animate from.
+    const [entered, setEntered] = useState(false)
+    useEffect(() => setEntered(true), [])
+    const open = entered && !call.ended
 
     useEffect(() => {
       const onPointer = (e: MouseEvent) => {
@@ -43,11 +56,11 @@ export const SettingsDrawer = createCallable<Props, Settings | null>(
         role="dialog"
         aria-modal="true"
         aria-label="Settings"
-        className="fixed inset-0 z-50 flex justify-end bg-black/50 backdrop-blur-sm"
+        className={`fixed inset-0 z-50 flex justify-end bg-black/50 backdrop-blur-sm transition-opacity duration-300 ${open ? 'opacity-100' : 'opacity-0'}`}
       >
         <div
           ref={drawerRef}
-          className="flex h-full w-full max-w-sm flex-col border-l border-[var(--color-border)] bg-[var(--color-bg)] shadow-2xl"
+          className={`flex h-full w-full max-w-sm flex-col border-l border-[var(--color-border)] bg-[var(--color-bg)] shadow-2xl transition-transform duration-300 ease-out ${open ? 'translate-x-0' : 'translate-x-full'}`}
         >
           <div className="flex items-center justify-between border-b border-[var(--color-border)] px-6 py-4">
             <p className="text-base font-medium text-[var(--color-fg)]">
@@ -121,6 +134,7 @@ export const SettingsDrawer = createCallable<Props, Settings | null>(
       </div>
     )
   },
+  UNMOUNTING_DELAY,
 )
 SettingsDrawer.displayName = 'SettingsDrawer'
 

--- a/sites/web/src/examples/side-drawer/meta.ts
+++ b/sites/web/src/examples/side-drawer/meta.ts
@@ -3,9 +3,9 @@ import type { ExampleMeta } from '~/lib/examples'
 export const meta = {
   title: 'Settings drawer',
   description:
-    'A panel that slides in from the edge. Props carry the initial settings as plain data; the Callable owns its own form state and resolves with the saved values, or null if the user dismisses.',
+    'A panel that slides in from the edge and slides back out on close. Props carry the initial settings as plain data; the Callable owns its own form state and resolves with the saved values, or null if the user dismisses.',
   category: 'drawer',
-  behaviors: [],
+  behaviors: ['exit-animation'],
   tags: ['settings', 'panel', 'form'],
   files: { callable: 'SettingsDrawer.tsx', caller: 'OpenSettingsButton.tsx' },
   order: 41,

--- a/sites/web/src/examples/side-drawer/notes.mdx
+++ b/sites/web/src/examples/side-drawer/notes.mdx
@@ -1,0 +1,34 @@
+## Animating the exit
+
+A call normally unmounts the instant `call.end()` runs — fine for a fade,
+fatal for a slide-out, which never gets to play. The second argument to
+`createCallable` is an **unmounting delay** in milliseconds: react-call
+keeps the finished call in the stack that long before dropping it, and
+flips `call.ended` to `true` for the duration.
+
+```tsx
+const UNMOUNTING_DELAY = 300 // match your CSS transition
+
+export const SettingsDrawer = createCallable<Props, Settings | null>(
+  ({ call }) => {
+    const open = entered && !call.ended
+    // open ? 'translate-x-0' : 'translate-x-full'
+  },
+  UNMOUNTING_DELAY,
+)
+```
+
+So there are two transitions driven by one `open` flag:
+
+- **In** — `entered` starts `false` and flips on the next animation frame,
+  so the panel mounts off-screen and slides in.
+- **Out** — `call.end(...)` sets `call.ended`, `open` goes `false`, the
+  panel slides back out, and react-call unmounts it once the delay elapses.
+
+## Gotchas
+
+- **Keep the delay and the CSS duration in sync.** Too short and the exit
+  is cut off; too long and the call lingers invisibly.
+- `call.ended` is per-call — a click-outside, a button, or an external
+  `SettingsDrawer.end(null)` all route through the same window, so every
+  close animates the same way.

--- a/sites/web/src/lib/code-marks.test.ts
+++ b/sites/web/src/lib/code-marks.test.ts
@@ -156,4 +156,22 @@ describe('buildAppSource + appRootMeta', () => {
     // Import is line 1; the <Confirm /> mount is line 7.
     expect(appRootMeta(app, 'Confirm')).toBe('{1,7}')
   })
+
+  test('splices Root props into the mount and still marks the same lines', () => {
+    const app = buildAppSource(
+      'Greeter',
+      'GreetButton',
+      'userName="Ada Lovelace"',
+    )
+    expect(app).toContain('<Greeter userName="Ada Lovelace" />')
+    expect(appRootMeta(app, 'Greeter')).toBe('{1,7}')
+  })
+
+  test('does not mark a caller mount that merely shares the Callable prefix', () => {
+    // Callable "Confirm", caller "ConfirmButton" — only the import (line 1)
+    // and the <Confirm /> mount (line 7) carry the Root contract; the
+    // <ConfirmButton /> mount on line 8 must stay unmarked.
+    const app = buildAppSource('Confirm', 'ConfirmButton')
+    expect(appRootMeta(app, 'Confirm')).toBe('{1,7}')
+  })
 })

--- a/sites/web/src/lib/code-marks.ts
+++ b/sites/web/src/lib/code-marks.ts
@@ -220,10 +220,16 @@ export const rewriteCallableImport = (
     `from './${callableExport}'`,
   )
 
-/** Builds the minimal App.tsx that mounts the Root next to the caller. */
+/**
+ * Builds the minimal App.tsx that mounts the Root next to the caller.
+ * `rootProps` is an optional JSX attribute string (e.g. `userName="Ada"`)
+ * spliced into the Root mount — set it for examples that read `call.root`
+ * so the generated App shows where those Root props come from.
+ */
 export const buildAppSource = (
   callableExport: string,
   callerExport: string,
+  rootProps?: string,
 ): string =>
   `import { ${callableExport} } from './${callableExport}'
 import { ${callerExport} } from './${callerExport}'
@@ -231,7 +237,7 @@ import { ${callerExport} } from './${callerExport}'
 export default function App() {
   return (
     <>
-      <${callableExport} />
+      <${callableExport}${rootProps ? ` ${rootProps}` : ''} />
       <${callerExport} />
     </>
   )
@@ -240,18 +246,19 @@ export default function App() {
 
 /**
  * Marks the two lines of the generated App.tsx that carry the Root
- * contract: the Callable import and the `<Callable />` mount.
+ * contract: the Callable import and the `<Callable … />` mount (with or
+ * without Root props). The mount matcher requires a delimiter after the
+ * name so `<Confirm />` matches but a `<ConfirmButton />` caller mount,
+ * which merely starts with the same prefix, does not.
  */
 export const appRootMeta = (
   appSource: string,
   callableExport: string,
 ): string => {
+  const mountRe = new RegExp(`<${callableExport}[\\s/>]`)
   const marked: number[] = []
   appSource.split('\n').forEach((line, i) => {
-    if (
-      line.includes(`from './${callableExport}'`) ||
-      line.includes(`<${callableExport} />`)
-    ) {
+    if (line.includes(`from './${callableExport}'`) || mountRe.test(line)) {
       marked.push(i + 1)
     }
   })

--- a/sites/web/src/lib/examples.ts
+++ b/sites/web/src/lib/examples.ts
@@ -13,6 +13,9 @@ export type Behavior =
   | 'mutation-flow'
   | 'stacking'
   | 'nested'
+  | 'exit-animation'
+  | 'root-props'
+  | 'end-from-caller'
 
 export interface ExampleMeta {
   title: string
@@ -24,6 +27,14 @@ export interface ExampleMeta {
     callable: string
     caller: string
   }
+  /**
+   * JSX attribute string spliced into the Root mount of the generated
+   * App.tsx (and the CodeSandbox export), e.g. `userName="Ada Lovelace"`.
+   * Set this on examples that read `call.root` so the displayed Root
+   * actually shows where those Root props come from. Omit for the common
+   * case where the Root takes no props.
+   */
+  rootProps?: string
   order?: number
 }
 
@@ -124,4 +135,7 @@ export const BEHAVIOR_LABELS: Record<Behavior, string> = {
   'mutation-flow': 'Mutation flow',
   stacking: 'Stacking',
   nested: 'Nested',
+  'exit-animation': 'Exit animation',
+  'root-props': 'Root props',
+  'end-from-caller': 'End from caller',
 }

--- a/sites/web/src/pages/examples/[slug].astro
+++ b/sites/web/src/pages/examples/[slug].astro
@@ -53,7 +53,11 @@ const callerMeta = highlightedLines(displayCallerSource)
 // A minimal App.tsx mounting the Root next to the caller. The Callable
 // import and the <Callable /> mount are both marked so the visitor sees
 // the whole wiring at once.
-const appSource = buildAppSource(callableExport, callerExport)
+const appSource = buildAppSource(
+  callableExport,
+  callerExport,
+  example.meta.rootProps,
+)
 const appMeta = appRootMeta(appSource, callableExport)
 ---
 
@@ -111,6 +115,7 @@ const appMeta = appRootMeta(appSource, callableExport)
           callableSource={example.callableSource}
           callerFilename={example.meta.files.caller}
           callerSource={example.callerSource}
+          rootProps={example.meta.rootProps}
         />
       </div>
     </section>


### PR DESCRIPTION
## What & why

Audited the gallery against the README and found library features with **no live example**. This fills those gaps and surfaces a couple that were under-demonstrated.

## New examples

| Example | README feature | Demonstrates |
|---|---|---|
| **Account-aware dialog** (`root-context`) | Passing Root props | `call.root.userName` flowing from `<Greeter userName="…" />` |
| **Confirm with optional async** (`optional-mutation`) | Optional `mutationFn` + `.orEnd()` | same Callable: no handler → instant fallback; with handler → pending → close |
| **Resolve from the caller** (`caller-resolve`) | End from caller | a timeout settles the open call via `Approval.end(promise, false)` |
| **Broadcast to every call** (`broadcast-update`) | `update(props)` with no promise | one broadcast merges into all open pills, each keeping its own label |

## Edits to existing examples

- **Settings drawer** and **Bottom sheet**: real exit animations via the `unmountingDelay` second arg + `call.ended` (slide-in on mount, slide-out on close), with notes.

## Infra / supporting changes

- Optional `rootProps` field on `ExampleMeta`, threaded through the generated `App.tsx` (`code-marks`) and the CodeSandbox export (`PlaygroundButton`) so a Root-props example actually shows where the prop is passed. Unit tests updated.
- New behavior tags: `exit-animation`, `root-props`, `end-from-caller`.
- Dropped the redundant "Behaviors" label from the gallery filter row (the pills are self-describing).

## Verification

- `code-marks` unit tests pass (21); biome clean; `astro build` generates all 21 example routes; pre-commit `tsc -b` + lint green.
- Manually exercised all six changes in the dev preview (Root-props rendering + generated App block, both `.orEnd`/handler paths, timeout + manual approval, broadcast merge across a stack, drawer/sheet enter+exit).

## Follow-up (separate)

While building `broadcast-update` I hit a library behavior worth a look: calling `X.end()` (end-all) and then `X.call()` in the **same synchronous tick** leaves the new calls unrendered. The example's caller was written to avoid that pattern; flagged for investigation in `packages/react-call` separately. — Fixed in #96 