### PR TITLE
feat(web): mobile header, refreshed landing grid, and example fixes

### DIFF
--- a/sites/web/src/components/Header.astro
+++ b/sites/web/src/components/Header.astro
@@ -1,4 +1,5 @@
 ---
+import { MobileNav } from './MobileNav'
 import { ThemeToggle } from './ThemeToggle'
 
 const navItems = [
@@ -6,6 +7,16 @@ const navItems = [
   { href: '/examples', label: 'Examples' },
   { href: '/concepts', label: 'Concepts' },
 ]
+
+const referenceLink = {
+  href: 'https://github.com/desko27/react-call#readme',
+  label: 'Full reference ↗',
+  external: true,
+}
+
+// Below `md` every secondary link collapses into the hamburger; the Star
+// CTA stays in the bar as an icon-only button.
+const mobileLinks = [...navItems, referenceLink]
 ---
 
 <header
@@ -31,7 +42,7 @@ const navItems = [
         class="text-[var(--color-accent)]"
         aria-hidden="true">●</span
       >
-      <span class="hidden items-start gap-1 sm:flex">
+      <span class="flex items-start gap-1">
         react-call
         <span
           class="text-xs font-normal leading-none text-[var(--color-fg-subtle)]"
@@ -41,41 +52,42 @@ const navItems = [
     </a>
 
     <nav class="flex items-center gap-3 sm:gap-6">
-      {
-        navItems.map((item) => (
-          <a
-            href={item.href}
-            class="text-sm text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]"
-          >
-            {item.label}
-          </a>
-        ))
-      }
-      <a
-        href="https://github.com/desko27/react-call#readme"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="
-          hidden whitespace-nowrap text-sm text-[var(--color-fg-muted)]
-          transition-colors hover:text-[var(--color-fg)]
-          md:inline
-        "
-      >
-        Full reference ↗
-      </a>
+      <div class="hidden items-center gap-6 md:flex">
+        {
+          navItems.map((item) => (
+            <a
+              href={item.href}
+              class="text-sm text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]"
+            >
+              {item.label}
+            </a>
+          ))
+        }
+        <a
+          href={referenceLink.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="
+            whitespace-nowrap text-sm text-[var(--color-fg-muted)]
+            transition-colors hover:text-[var(--color-fg)]
+          "
+        >
+          {referenceLink.label}
+        </a>
+      </div>
       <a
         href="https://github.com/desko27/react-call"
         target="_blank"
         rel="noopener noreferrer"
         aria-label="Star react-call on GitHub"
         class="
-          hidden items-center gap-1.5 rounded-md
+          inline-flex items-center justify-center gap-1.5 rounded-md
           border border-[var(--color-border-strong)]
-          px-3 py-1.5
+          h-9 w-9 px-0 py-0
+          md:h-auto md:w-auto md:px-3 md:py-1.5
           text-sm text-[var(--color-fg-muted)]
           transition-colors
           hover:bg-[var(--color-bg-muted)] hover:text-[var(--color-fg)]
-          min-[400px]:inline-flex
         "
       >
         <svg
@@ -88,9 +100,12 @@ const navItems = [
             d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
           ></path>
         </svg>
-        Star
+        <span class="hidden md:inline">Star</span>
       </a>
       <ThemeToggle client:load />
+      <div class="md:hidden">
+        <MobileNav links={mobileLinks} client:load />
+      </div>
     </nav>
   </div>
 </header>

--- a/sites/web/src/components/MobileNav.tsx
+++ b/sites/web/src/components/MobileNav.tsx
@@ -1,0 +1,117 @@
+import clsx from 'clsx'
+import { useEffect, useId, useRef, useState } from 'react'
+
+interface NavLink {
+  href: string
+  label: string
+  external?: boolean
+}
+
+interface MobileNavProps {
+  links: NavLink[]
+}
+
+/**
+ * Disclosure-pattern hamburger for the header below `md`. The links are
+ * always rendered (toggled via CSS, never conditionally mounted) so they
+ * stay in the static HTML and remain crawlable.
+ */
+export const MobileNav = ({ links }: MobileNavProps) => {
+  const [open, setOpen] = useState(false)
+  const panelId = useId()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+        buttonRef.current?.focus()
+      }
+    }
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('pointerdown', onPointerDown)
+    }
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-label={open ? 'Close menu' : 'Open menu'}
+        aria-expanded={open}
+        aria-controls={panelId}
+        className="
+          inline-flex h-9 w-9 items-center justify-center rounded-md
+          border border-[var(--color-border)]
+          bg-[var(--color-bg-subtle)]
+          text-[var(--color-fg-muted)]
+          transition-colors
+          hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg)]
+        "
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          {open ? (
+            <path d="M18 6 6 18M6 6l12 12" />
+          ) : (
+            <path d="M3 6h18M3 12h18M3 18h18" />
+          )}
+        </svg>
+      </button>
+
+      <nav
+        id={panelId}
+        aria-label="Site"
+        className={clsx(
+          'absolute top-full right-0 z-50 mt-2 min-w-44',
+          'rounded-md border border-[var(--color-border)]',
+          'bg-[var(--color-bg)] p-1.5 shadow-lg shadow-black/5',
+          open ? 'block' : 'hidden',
+        )}
+      >
+        {links.map((link) => (
+          <a
+            key={link.href}
+            href={link.href}
+            {...(link.external
+              ? { target: '_blank', rel: 'noopener noreferrer' }
+              : {})}
+            className="
+              block whitespace-nowrap rounded px-3 py-2
+              text-sm text-[var(--color-fg-muted)]
+              transition-colors
+              hover:bg-[var(--color-bg-muted)] hover:text-[var(--color-fg)]
+            "
+          >
+            {link.label}
+          </a>
+        ))}
+      </nav>
+    </div>
+  )
+}

--- a/sites/web/src/components/landing/NotJustConfirmations.tsx
+++ b/sites/web/src/components/landing/NotJustConfirmations.tsx
@@ -1,13 +1,13 @@
 import { type MouseEvent, useState } from 'react'
+import { BottomSheet } from '~/examples/bottom-sheet/callable'
 import { ColorPicker } from '~/examples/color-picker/callable'
 import {
   type Command,
   CommandPalette,
 } from '~/examples/command-palette/callable'
-import { Confirm } from '~/examples/confirm-dialog/callable'
 import { ContextMenu } from '~/examples/context-menu/callable'
-import { Lightbox } from '~/examples/image-lightbox/callable'
 import { Toast } from '~/examples/progress-toast/callable'
+import { Wizard } from '~/examples/wizard/callable'
 import { type Result, ResultBadge } from './ResultBadge'
 
 const SWATCHES = [
@@ -26,18 +26,19 @@ const COMMANDS: readonly Command[] = [
   { id: 'restart', label: 'Restart' },
 ]
 
+const SHEET_ACTIONS = [
+  { id: 'share', label: 'Share', icon: '⇪' },
+  { id: 'copy-link', label: 'Copy link', icon: '⤴' },
+  { id: 'pin', label: 'Pin', icon: '📌' },
+  { id: 'archive', label: 'Archive', icon: '🗄' },
+] as const
+
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms))
 
 const formatString = (v: string | null): Result => ({
   value: v ?? 'null',
   highlighted: v !== null,
-  ts: Date.now(),
-})
-
-const formatBool = (v: boolean): Result => ({
-  value: String(v),
-  highlighted: v,
   ts: Date.now(),
 })
 
@@ -109,38 +110,27 @@ interface Props {
 }
 
 export const NotJustConfirmations = ({ exampleCount }: Props) => {
-  const fireConfirm = async (): Promise<Result> => {
-    const v = await Confirm.call({ message: 'A real .call() — same as yours.' })
-    return formatBool(v)
-  }
-
-  const fireToast = async (): Promise<Result> => {
-    Toast.upsert({ message: 'Starting…', percent: 0 })
-    for (let p = 20; p <= 100; p += 20) {
-      await sleep(180)
-      Toast.upsert({ message: `Working… ${p}%`, percent: p })
-    }
-    await sleep(500)
-    Toast.end()
-    return formatVoid('done')
-  }
-
-  const firePicker = async (): Promise<Result> => {
-    const v = await ColorPicker.call({ swatches: SWATCHES })
-    return formatString(v)
-  }
-
   const fireCommand = async (): Promise<Result> => {
     const v = await CommandPalette.call({ commands: COMMANDS })
     return formatString(v)
   }
 
-  const fireLightbox = async (): Promise<Result> => {
-    await Lightbox.call({
-      src: 'https://images.unsplash.com/photo-1518770660439-4636190af475?w=1400',
-      alt: 'Circuit board',
+  const fireBottomSheet = async (): Promise<Result> => {
+    const v = await BottomSheet.call({
+      title: 'Quick actions',
+      actions: SHEET_ACTIONS,
     })
-    return formatVoid('closed')
+    return formatString(v)
+  }
+
+  const fireWizard = async (): Promise<Result> => {
+    const data = await Wizard.call()
+    return data ? formatVoid(`${data.name} · ${data.plan}`) : formatString(null)
+  }
+
+  const firePicker = async (): Promise<Result> => {
+    const v = await ColorPicker.call({ swatches: SWATCHES })
+    return formatString(v)
   }
 
   const fireContextMenu = async (e?: MouseEvent): Promise<Result> => {
@@ -159,14 +149,25 @@ export const NotJustConfirmations = ({ exampleCount }: Props) => {
     return formatString(v)
   }
 
+  const fireToast = async (): Promise<Result> => {
+    Toast.upsert({ message: 'Starting…', percent: 0 })
+    for (let p = 20; p <= 100; p += 20) {
+      await sleep(180)
+      Toast.upsert({ message: `Working… ${p}%`, percent: p })
+    }
+    await sleep(500)
+    Toast.end()
+    return formatVoid('done')
+  }
+
   return (
     <>
-      <Confirm />
-      <Toast />
-      <ColorPicker />
       <CommandPalette />
-      <Lightbox />
+      <BottomSheet />
+      <Wizard />
+      <ColorPicker />
       <ContextMenu />
+      <Toast />
 
       <section className="mx-auto max-w-6xl px-6 py-24">
         <div className="text-center">
@@ -186,18 +187,25 @@ export const NotJustConfirmations = ({ exampleCount }: Props) => {
 
         <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           <Card
-            slug="confirm-dialog"
-            category="Dialog"
-            title="Confirm"
-            description="The simplest case. Returns a boolean to the caller."
-            onTry={fireConfirm}
+            slug="command-palette"
+            category="Menu"
+            title="Command palette"
+            description="⌘K-style search. Arrow keys to navigate, Enter to run."
+            onTry={fireCommand}
           />
           <Card
-            slug="progress-toast"
-            category="Notification"
-            title="Progress toast"
-            description="A singleton that updates itself via upsert() as work progresses."
-            onTry={fireToast}
+            slug="bottom-sheet"
+            category="Drawer"
+            title="Bottom sheet"
+            description="Slides up from the bottom — resolves with the action you tap."
+            onTry={fireBottomSheet}
+          />
+          <Card
+            slug="wizard"
+            category="Flow"
+            title="Multi-step wizard"
+            description="A 3-step signup — one await resolves with the whole form."
+            onTry={fireWizard}
           />
           <Card
             slug="color-picker"
@@ -207,13 +215,6 @@ export const NotJustConfirmations = ({ exampleCount }: Props) => {
             onTry={firePicker}
           />
           <Card
-            slug="command-palette"
-            category="Menu"
-            title="Command palette"
-            description="⌘K-style search. Arrow keys to navigate, Enter to run."
-            onTry={fireCommand}
-          />
-          <Card
             slug="context-menu"
             category="Menu"
             title="Context menu"
@@ -221,11 +222,11 @@ export const NotJustConfirmations = ({ exampleCount }: Props) => {
             onTry={fireContextMenu}
           />
           <Card
-            slug="image-lightbox"
-            category="Overlay"
-            title="Image lightbox"
-            description="Open a fullscreen overlay. Backdrop or Esc closes."
-            onTry={fireLightbox}
+            slug="progress-toast"
+            category="Notification"
+            title="Progress toast"
+            description="A singleton that updates itself via upsert() as work progresses."
+            onTry={fireToast}
           />
         </div>
 

--- a/sites/web/src/components/landing/NotJustConfirmations.tsx
+++ b/sites/web/src/components/landing/NotJustConfirmations.tsx
@@ -66,10 +66,16 @@ const Card = ({
   onTry,
 }: CardProps) => {
   const [result, setResult] = useState<Result | null>(null)
+  const [pending, setPending] = useState(false)
 
   const handleClick = async (e: MouseEvent) => {
-    const next = await onTry(e)
-    setResult(next)
+    setPending(true)
+    try {
+      const next = await onTry(e)
+      setResult(next)
+    } finally {
+      setPending(false)
+    }
   }
 
   return (
@@ -87,7 +93,8 @@ const Card = ({
         <button
           type="button"
           onClick={handleClick}
-          className="rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg)] px-3 py-1.5 text-xs text-[var(--color-fg)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+          disabled={pending}
+          className="rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg)] px-3 py-1.5 text-xs text-[var(--color-fg)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] disabled:opacity-50"
         >
           {buttonLabel}
         </button>
@@ -125,7 +132,9 @@ export const NotJustConfirmations = ({ exampleCount }: Props) => {
 
   const fireWizard = async (): Promise<Result> => {
     const data = await Wizard.call()
-    return data ? formatVoid(`${data.name} · ${data.plan}`) : formatString(null)
+    return data
+      ? formatVoid(`${data.name} · ${data.email} · ${data.plan}`)
+      : formatString(null)
   }
 
   const firePicker = async (): Promise<Result> => {

--- a/sites/web/src/examples/command-palette/callable.tsx
+++ b/sites/web/src/examples/command-palette/callable.tsx
@@ -75,13 +75,16 @@ export const CommandPalette = createCallable<Props, string | null>(
           ref={paletteRef}
           className="w-full max-w-md overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] shadow-2xl"
         >
+          {/* text-base (16px) on mobile stops iOS Safari from auto-zooming
+              when the input autofocuses on open; md:text-sm restores the
+              compact size on larger screens. */}
           <input
             ref={inputRef}
             type="text"
             placeholder="Type a command…"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="w-full border-b border-[var(--color-border)] bg-transparent px-4 py-3 text-sm text-[var(--color-fg)] focus:outline-none"
+            className="w-full border-b border-[var(--color-border)] bg-transparent px-4 py-3 text-base text-[var(--color-fg)] focus:outline-none md:text-sm"
           />
           <ul ref={listRef} className="max-h-72 overflow-y-auto p-1">
             {filtered.length === 0 ? (

--- a/sites/web/src/examples/progress-toast/callable.tsx
+++ b/sites/web/src/examples/progress-toast/callable.tsx
@@ -5,12 +5,17 @@ interface Props {
   percent?: number
 }
 
+// px per stacked toast, including the gap — offsets concurrent calls so
+// they stack upward instead of overlapping (same idea as error-banner).
+const ROW_HEIGHT = 84
+
 export const Toast = createCallable<Props, void>(
   ({ call, message, percent }) => (
     <div
       role="status"
       aria-live="polite"
-      className="pointer-events-none fixed bottom-6 right-6 z-50"
+      style={{ bottom: 24 + call.index * ROW_HEIGHT }}
+      className="pointer-events-none fixed right-6 z-50 transition-[bottom] duration-200"
     >
       <div className="pointer-events-auto min-w-[280px] rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-4 shadow-2xl">
         <div className="flex items-start justify-between gap-3">

--- a/sites/web/src/examples/prompt-input/callable.tsx
+++ b/sites/web/src/examples/prompt-input/callable.tsx
@@ -42,7 +42,7 @@ export const Prompt = createCallable<Props, string | null>(
             value={value}
             placeholder={placeholder}
             onChange={(e) => setValue(e.target.value)}
-            className="mt-4 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-subtle)] px-3 py-2 text-sm text-[var(--color-fg)] focus:border-[var(--color-accent)] focus:outline-none"
+            className="mt-4 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-subtle)] px-3 py-2 text-base text-[var(--color-fg)] focus:border-[var(--color-accent)] focus:outline-none md:text-sm"
           />
           <div className="mt-6 flex items-center justify-end gap-3">
             <button

--- a/sites/web/src/examples/save-form/callable.tsx
+++ b/sites/web/src/examples/save-form/callable.tsx
@@ -29,7 +29,7 @@ export const SaveForm = createCallable<Props, string>(
             onChange={(e) => setName(e.target.value)}
             disabled={submit.pending}
             placeholder="Item name"
-            className="mt-4 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-subtle)] px-3 py-2 text-sm text-[var(--color-fg)] focus:border-[var(--color-accent)] focus:outline-none disabled:opacity-50"
+            className="mt-4 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-subtle)] px-3 py-2 text-base text-[var(--color-fg)] focus:border-[var(--color-accent)] focus:outline-none disabled:opacity-50 md:text-sm"
           />
           <label className="mt-3 flex items-center gap-2 text-xs text-[var(--color-fg-subtle)]">
             <input

--- a/sites/web/src/examples/side-drawer/callable.tsx
+++ b/sites/web/src/examples/side-drawer/callable.tsx
@@ -105,7 +105,7 @@ export const SettingsDrawer = createCallable<Props, Settings | null>(
                     theme: e.target.value as Theme,
                   })
                 }
-                className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-subtle)] px-2 py-1 text-sm text-[var(--color-fg)] focus:border-[var(--color-accent)] focus:outline-none"
+                className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-subtle)] px-2 py-1 text-base text-[var(--color-fg)] focus:border-[var(--color-accent)] focus:outline-none md:text-sm"
               >
                 <option value="system">System</option>
                 <option value="light">Light</option>

--- a/sites/web/src/examples/wizard/callable.tsx
+++ b/sites/web/src/examples/wizard/callable.tsx
@@ -7,6 +7,11 @@ export interface WizardResult {
   plan: 'free' | 'pro' | 'team'
 }
 
+// text-base (16px) on mobile stops iOS Safari from auto-zooming when a
+// step input autofocuses; md:text-sm restores the compact size on desktop.
+const INPUT_CLASS =
+  'w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-subtle)] px-3 py-2 text-base text-[var(--color-fg)] focus:border-[var(--color-accent)] focus:outline-none md:text-sm'
+
 export const Wizard = createCallable<void, WizardResult | null>(({ call }) => {
   const [step, setStep] = useState(0)
   const [name, setName] = useState('')
@@ -54,7 +59,7 @@ export const Wizard = createCallable<void, WizardResult | null>(({ call }) => {
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Ada Lovelace"
-              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-subtle)] px-3 py-2 text-sm text-[var(--color-fg)] focus:border-[var(--color-accent)] focus:outline-none"
+              className={INPUT_CLASS}
             />
           </Step>
         )}
@@ -67,7 +72,7 @@ export const Wizard = createCallable<void, WizardResult | null>(({ call }) => {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="ada@example.com"
-              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-subtle)] px-3 py-2 text-sm text-[var(--color-fg)] focus:border-[var(--color-accent)] focus:outline-none"
+              className={INPUT_CLASS}
             />
           </Step>
         )}

--- a/sites/web/src/examples/wizard/callable.tsx
+++ b/sites/web/src/examples/wizard/callable.tsx
@@ -35,7 +35,7 @@ export const Wizard = createCallable<void, WizardResult | null>(({ call }) => {
       role="dialog"
       aria-modal="true"
       aria-label="Wizard"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
     >
       <div className="w-full max-w-md rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-6 shadow-2xl">
         <div className="mb-5 flex items-center gap-2">


### PR DESCRIPTION
Several related web-site changes, all touching the public landing and its examples.

---

## 1. Keep the wordmark on mobile (hamburger menu)

The `react-call v2` **wordmark** was hidden below `sm`, leaving only the `●` logomark on phones. This keeps the wordmark visible at **every** resolution and collapses the secondary header links into a single hamburger menu below `md`.

| | Layout |
|---|---|
| **< 768px** (`md`) | `● react-call v2` ··· `★ 🌙 ☰` — menu holds Why / Examples / Concepts / Full reference ↗ |
| **≥ 768px** | All inline (the current desktop, **unchanged**) |

**Decisions (from a grilling session):**
- **Consolidated menu, one breakpoint.** A single `md` switch replaces the old fragmented `400 / 640 / 768` breakpoints — nothing gets orphaned mid-resize.
- **Star CTA stays in the bar** as an icon-only button. GitHub stars are the library's success metric, so the primary CTA shouldn't hide behind a tap.
- **React island** (`MobileNav.tsx`), consistent with the existing `ThemeToggle` idiom. React already hydrates on every page, so the marginal cost is ~nil.
- **ARIA disclosure pattern** (not a `role=menu` widget, which APG discourages for site nav): `aria-expanded` / `aria-controls`, Escape + click-outside to close, focus stays on the trigger, no focus-trap / scroll-lock / scrim.
- **SEO-safe by construction.** The menu's links are always rendered and only toggled via CSS — never `{open && …}` — so they stay in the static HTML and remain crawlable. (The footer also links them statically as a safety net.)

## 2. Refresh the landing example grid

Re-curated the six featured Callables in `NotJustConfirmations` so the grid stops duplicating concepts the **rest of the landing already covers**, and instead showcases the widest spread of distinct surfaces.

The hero already demonstrates a confirm, and the **Stack** and **Mutation-flow** sections own those concepts — so `confirm-dialog` (a hero clone) and `image-lightbox` make way for **bottom-sheet** (drawer) and **wizard** (flow), two categories the page did not surface anywhere else.

| # | Card | Category | |
|---|------|----------|---|
| 1 | Command palette | Menu | kept |
| 2 | **Bottom sheet** | **Drawer** | new |
| 3 | **Multi-step wizard** | **Flow** | new |
| 4 | Color picker | Picker | kept |
| 5 | Context menu | Menu | kept |
| 6 | Progress toast | Notification | kept |

Out: `confirm-dialog`, `image-lightbox`. Each card still fires a real `.call()` on the page; the two new ones were wired with their Callables, Roots and result badges.

## 3. Example bug fixes

Surfaced while testing the refreshed grid on a phone:

- **Toasts stack instead of overlapping.** The `Toast` Callable rendered every active call at the same fixed corner. It now offsets each by `call.index` (same pattern as `error-banner`), so concurrent toasts stack upward. The landing card stays a `upsert` singleton by design — and its "Try it" button is now disabled while the call is in flight, mirroring the example page's `DownloadButton`.
- **No more iOS focus-zoom on inputs.** iOS Safari auto-zooms when a focused input is < 16px. The autofocused inputs in **command palette** and **wizard**, plus the remaining example text inputs (**save-form**, **prompt-input**) and the **side-drawer** select, now use `text-base` (16px) on mobile with `md:text-sm` to keep the compact size on desktop.
- **Wizard dialog gutter.** The wizard overlay sat flush against the screen edges on mobile — added `p-4` so the panel keeps a 16px lateral margin.
- **Wizard result badge** now includes the email (`name · email · plan`); it previously showed only `name · plan`.

---

## Verification

- **Header** — Mobile (375px): wordmark visible, bar ends `★ 🌙 ☰` (hamburger last), controls height-aligned. Dropdown opens anchored top-right with the 4 links, icon morphs to `✕`. Desktop (1280px): full inline nav, hamburger hidden — unchanged.
- **Grid** — snapshot confirms the 6 cards in order with the two old ones gone. Drove both new Callables live: bottom-sheet resolves with the tapped action (`share`); the wizard runs its 3 steps and resolves with the structured form (`Ada · ada@example.com · team`). No console errors.
- **Fixes** — verified on the running dev server: input font-size is 16px at mobile / 14px at desktop; the wizard panel sits 16px from each edge at 375px; the toast card button disables during the run and re-enables after; the wizard badge shows all three values.
- `biome check` clean; pre-commit lint + type-check green on every commit. (The 2 pre-existing `astro check` errors in `astro.config.ts` and `examples/[slug].astro` are unrelated.)