### PR TITLE
Adopt react-call() wordmark, retiring the accent dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@
 
 `createCallable()` turns a React component into something you can `await`.
 
-Good fits: confirmations, dialogs, form modals, toasts, notifications, context
-menus, pickers — any UI that conceptually returns a value to its caller.
-
 
 <p align="center">
   <a href="https://react-call.desko.dev">
     <img alt="react-call — call your React components" src="./docs/assets/hero.png" />
   </a>
 </p>
+
+Good fits: confirmations, dialogs, form modals, toasts, notifications, context
+menus, pickers — any UI that conceptually returns a value to its caller.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 <div align="center">
   <h1>
-    ⚛️ 📡 <a href="https://react-call.desko.dev">react-call</a>
+    <a href="https://react-call.desko.dev">
+      <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="./docs/assets/wordmark-dark.svg" />
+        <img alt="react-call" src="./docs/assets/wordmark-light.svg" height="40" />
+      </picture>
+    </a>
   </h1>
 
   <p><em>Call your React components like async functions — they resolve with a value.</em></p>

--- a/docs/assets/wordmark-dark.svg
+++ b/docs/assets/wordmark-dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="52" viewBox="0 0 300 52" role="img" aria-label="react-call()">
+  <text x="2" y="38" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="40" font-weight="500" fill="#fafafa">react-call<tspan fill="#ff3a8e">()</tspan></text>
+</svg>

--- a/docs/assets/wordmark-light.svg
+++ b/docs/assets/wordmark-light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="52" viewBox="0 0 300 52" role="img" aria-label="react-call()">
+  <text x="2" y="38" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="40" font-weight="500" fill="#0a0a0a">react-call<tspan fill="#e11d74">()</tspan></text>
+</svg>

--- a/sites/web/public/favicon.svg
+++ b/sites/web/public/favicon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="14" fill="#e11d74"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><g fill="none" stroke="#e11d74" stroke-width="4" stroke-linecap="round"><path d="M14 5 Q6 16 14 27"/><path d="M18 5 Q26 16 18 27"/></g></svg>

--- a/sites/web/public/og.svg
+++ b/sites/web/public/og.svg
@@ -15,8 +15,7 @@
 
   <!-- Top-left brand -->
   <g transform="translate(80, 80)">
-    <circle cx="10" cy="10" r="10" fill="#e11d74"/>
-    <text x="32" y="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#fafafa">react-call</text>
+    <text x="0" y="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#fafafa">react-call<tspan fill="#ff3a8e">()</tspan></text>
   </g>
 
   <!-- Main copy: anchored to left edge with the same x as the brand mark (80) -->

--- a/sites/web/src/components/Footer.astro
+++ b/sites/web/src/components/Footer.astro
@@ -10,11 +10,12 @@ const year = new Date().getFullYear()
       class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between"
     >
       <div class="flex items-center gap-3">
-        <span
-          aria-hidden="true"
-          class="text-[var(--color-accent)]">●</span
+        <span class="font-mono text-sm text-[var(--color-fg)]"
+          >react-call<span
+            aria-hidden="true"
+            class="text-[var(--color-accent)]">()</span
+          ></span
         >
-        <span class="font-mono text-sm text-[var(--color-fg)]">react-call</span>
         <span class="text-xs text-[var(--color-fg-subtle)]">
           — your component can <span class="font-mono">await</span>.
         </span>

--- a/sites/web/src/components/Header.astro
+++ b/sites/web/src/components/Header.astro
@@ -21,6 +21,7 @@ const mobileLinks = [...navItems, referenceLink]
 
 <header
   class="
+    relative
     sticky top-0 z-40
     border-b border-[var(--color-border)]
     bg-[color-mix(in_srgb,var(--color-bg)_85%,transparent)]
@@ -80,6 +81,7 @@ const mobileLinks = [...navItems, referenceLink]
         </a>
       </div>
       <a
+        id="debug-star-cta"
         href="https://github.com/desko27/react-call"
         target="_blank"
         rel="noopener noreferrer"
@@ -112,4 +114,44 @@ const mobileLinks = [...navItems, referenceLink]
       </div>
     </nav>
   </div>
+
+  {/* TEMPORARY visual-check guides — remove before merge.
+      Red line at the header's 50% height, plus lines at the Star
+      button's top and bottom edges. */}
+  <div
+    aria-hidden="true"
+    class="pointer-events-none absolute inset-x-0 top-1/2 z-50 h-px -translate-y-1/2 bg-red-500"
+  >
+  </div>
+  <div
+    id="debug-star-top"
+    aria-hidden="true"
+    class="pointer-events-none absolute inset-x-0 z-50 h-px bg-red-500"
+  >
+  </div>
+  <div
+    id="debug-star-bottom"
+    aria-hidden="true"
+    class="pointer-events-none absolute inset-x-0 z-50 h-px bg-red-500"
+  >
+  </div>
 </header>
+
+<script>
+  // TEMPORARY: position the guide lines on the Star button's top/bottom
+  // edges, relative to the header. Remove together with the lines above.
+  function placeDebugGuides() {
+    const header = document.querySelector('header')
+    const star = document.getElementById('debug-star-cta')
+    const top = document.getElementById('debug-star-top')
+    const bottom = document.getElementById('debug-star-bottom')
+    if (!header || !star || !top || !bottom) return
+    const h = header.getBoundingClientRect()
+    const s = star.getBoundingClientRect()
+    top.style.top = `${s.top - h.top}px`
+    bottom.style.top = `${s.bottom - h.top}px`
+  }
+  placeDebugGuides()
+  window.addEventListener('resize', placeDebugGuides)
+  window.addEventListener('load', placeDebugGuides)
+</script>

--- a/sites/web/src/components/Header.astro
+++ b/sites/web/src/components/Header.astro
@@ -21,7 +21,6 @@ const mobileLinks = [...navItems, referenceLink]
 
 <header
   class="
-    relative
     sticky top-0 z-40
     border-b border-[var(--color-border)]
     bg-[color-mix(in_srgb,var(--color-bg)_85%,transparent)]
@@ -81,7 +80,6 @@ const mobileLinks = [...navItems, referenceLink]
         </a>
       </div>
       <a
-        id="debug-star-cta"
         href="https://github.com/desko27/react-call"
         target="_blank"
         rel="noopener noreferrer"
@@ -114,44 +112,4 @@ const mobileLinks = [...navItems, referenceLink]
       </div>
     </nav>
   </div>
-
-  {/* TEMPORARY visual-check guides — remove before merge.
-      Red line at the header's 50% height, plus lines at the Star
-      button's top and bottom edges. */}
-  <div
-    aria-hidden="true"
-    class="pointer-events-none absolute inset-x-0 top-1/2 z-50 h-px -translate-y-1/2 bg-red-500"
-  >
-  </div>
-  <div
-    id="debug-star-top"
-    aria-hidden="true"
-    class="pointer-events-none absolute inset-x-0 z-50 h-px bg-red-500"
-  >
-  </div>
-  <div
-    id="debug-star-bottom"
-    aria-hidden="true"
-    class="pointer-events-none absolute inset-x-0 z-50 h-px bg-red-500"
-  >
-  </div>
 </header>
-
-<script>
-  // TEMPORARY: position the guide lines on the Star button's top/bottom
-  // edges, relative to the header. Remove together with the lines above.
-  function placeDebugGuides() {
-    const header = document.querySelector('header')
-    const star = document.getElementById('debug-star-cta')
-    const top = document.getElementById('debug-star-top')
-    const bottom = document.getElementById('debug-star-bottom')
-    if (!header || !star || !top || !bottom) return
-    const h = header.getBoundingClientRect()
-    const s = star.getBoundingClientRect()
-    top.style.top = `${s.top - h.top}px`
-    bottom.style.top = `${s.bottom - h.top}px`
-  }
-  placeDebugGuides()
-  window.addEventListener('resize', placeDebugGuides)
-  window.addEventListener('load', placeDebugGuides)
-</script>

--- a/sites/web/src/components/Header.astro
+++ b/sites/web/src/components/Header.astro
@@ -33,17 +33,18 @@ const mobileLinks = [...navItems, referenceLink]
     <a
       href="/"
       class="
-        flex shrink-0 items-center gap-2
+        flex shrink-0 items-center
         font-mono text-sm font-medium whitespace-nowrap
         text-[var(--color-fg)]
       "
     >
-      <span
-        class="text-[var(--color-accent)]"
-        aria-hidden="true">●</span
-      >
       <span class="flex items-start gap-1">
-        react-call
+        <span
+          >react-call<span
+            class="text-[var(--color-accent)]"
+            aria-hidden="true">()</span
+          ></span
+        >
         <span
           class="text-xs font-normal leading-none text-[var(--color-fg-subtle)]"
           >v2</span

--- a/sites/web/src/components/Header.astro
+++ b/sites/web/src/components/Header.astro
@@ -31,9 +31,12 @@ const mobileLinks = [...navItems, referenceLink]
   <div
     class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6"
   >
+    {/* top-px: optical nudge — the mono wordmark's ink sits ~1px higher
+        than the sans nav text on the shared baseline, so drop it to match. */}
     <a
       href="/"
       class="
+        relative top-px
         flex shrink-0 items-center
         font-mono text-sm font-medium whitespace-nowrap
         text-[var(--color-fg)]

--- a/sites/web/src/components/Header.astro
+++ b/sites/web/src/components/Header.astro
@@ -30,9 +30,12 @@ const mobileLinks = [...navItems, referenceLink]
   <div
     class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6"
   >
+    {/* top-px: optical nudge — the mono wordmark's ink sits ~1px higher
+        than the sans nav text on the shared baseline, so drop it to match. */}
     <a
       href="/"
       class="
+        relative top-px
         flex shrink-0 items-center
         font-mono text-sm font-medium whitespace-nowrap
         text-[var(--color-fg)]

--- a/sites/web/src/components/Header.astro
+++ b/sites/web/src/components/Header.astro
@@ -31,12 +31,9 @@ const mobileLinks = [...navItems, referenceLink]
   <div
     class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6"
   >
-    {/* top-px: optical nudge — the mono wordmark's ink sits ~1px higher
-        than the sans nav text on the shared baseline, so drop it to match. */}
     <a
       href="/"
       class="
-        relative top-px
         flex shrink-0 items-center
         font-mono text-sm font-medium whitespace-nowrap
         text-[var(--color-fg)]


### PR DESCRIPTION
## What

Replaces the site brand mark — an accent dot + `react-call` — with **`react-call()`**, where the parentheses carry the accent color. The empty parens evoke the library's imperative `call()` method.

The accent dot is **fully retired**: the parens are now the sole accent-carrier across every brand surface.

## Changes

| Surface | Before | After |
|---|---|---|
| **Header** | `● react-call` + `v2` | `react-call()` + `v2` badge (parens accent; `v2` trails the parens, unchanged) |
| **Footer** | `● react-call` | `react-call()` (parens accent) |
| **Favicon** | solid accent circle | `()` redrawn as vector paths, `#e11d74` |
| **OG image** | `● react-call` top-left | `react-call()`, parens in `#ff3a8e` (matches the existing dark-bg accent) |

In the wordmark, only the two paren glyphs take `--color-accent`; `react-call` stays `--color-fg`. The header `v2` badge sits *outside* the parens so the call metaphor stays clean (a version inside `()` would read as a call argument).

The favicon — previously the dot itself — is redrawn as `()` in vector paths (two mirrored quadratic arcs, stroke-4, round caps) so it stays crisp and centered at 16px without depending on a system font.

## Notes

- No `CONTEXT.md` or ADR changes: a wordmark isn't a library-API domain term, and the change is trivially reversible (one span + two small SVGs), so it doesn't clear the ADR bar.
- `astro build` and `astro check` pass; built HTML confirms the new wordmark in header and footer.
