### PR TITLE
fix: correct footer license link path

### DIFF
--- a/sites/web/src/components/Footer.astro
+++ b/sites/web/src/components/Footer.astro
@@ -62,7 +62,7 @@ const year = new Date().getFullYear()
           class="transition-colors hover:text-[var(--color-fg)]">Issues</a
         >
         <a
-          href="https://github.com/desko27/react-call/blob/main/LICENSE"
+          href="https://github.com/desko27/react-call/blob/main/packages/react-call/LICENSE"
           target="_blank"
           rel="noopener noreferrer"
           class="transition-colors hover:text-[var(--color-fg)]">MIT</a


### PR DESCRIPTION
The MIT license link in the website footer pointed to the root `LICENSE` file, which doesn't exist. Updated it to the correct path at `packages/react-call/LICENSE`.